### PR TITLE
Flagging celllines

### DIFF
--- a/R/QC_images.R
+++ b/R/QC_images.R
@@ -22,7 +22,7 @@
 #' @param count_threshold - threshold for low counts
 #' @return - NA, QC images are written out to the specified folder
 #' @export
-QC_images = function(annotated_counts, filtered_counts, normalized_counts,
+QC_images = function(annotated_counts, filtered_counts, normalized_counts= NA,
                      CB_meta, cell_set_meta, out = NA, sig_cols, count_col_name= 'normalized_n',
                      count_threshold= 40) {
   if(is.na(out)) {
@@ -35,6 +35,7 @@ QC_images = function(annotated_counts, filtered_counts, normalized_counts,
     dplyr::filter(control_barcodes %in% c("Y", "T", T),
                   !(trt_type %in% c("empty", "", "CB_only")) & !is.na(trt_type))
   contains_cbs= ifelse(nrow(cb_check)!= 0, T, F)
+  #
   
   # Sequencing QCs ____________________ ----
   ## Index count summaries ----
@@ -222,6 +223,7 @@ QC_images = function(annotated_counts, filtered_counts, normalized_counts,
     dplyr::arrange(desc(num_wells))
   contams %>% write.csv(file= paste(out, 'contams.csv', sep='/'), row.names=F)
   #
+  
   ## Cumulative counts by lines in negcons ----
   print("generating cummulative image")
   cdf= filtered_counts %>% ungroup() %>% 
@@ -275,7 +277,7 @@ QC_images = function(annotated_counts, filtered_counts, normalized_counts,
   dev.off()
   
   ## Control barcode trends ----
-  if(contains_cbs) {
+  if(contains_cbs & is.data.frame(normalized_counts)) {
     print("generating control_barcode_trend image")
     cb_trend= normalized_counts %>% 
       dplyr::filter(control_barcodes %in% c("Y", "T", T),

--- a/R/QC_images.R
+++ b/R/QC_images.R
@@ -88,7 +88,7 @@ QC_images = function(annotated_counts, filtered_counts, normalized_counts= NA,
   ## Control barcode counts ----
   if(contains_cbs) { 
     print('generating control barcode counts')
-    idx_pairs_cbs= annotated_counts %>% dplyr::filter(!is.na(Name), !is.na(project_code)) %>%
+    idx_pairs_cbs= annotated_counts %>% dplyr::filter(!is.na(Name), expected_read) %>%
       dplyr::group_by(index_1, index_2, pcr_plate, pcr_well) %>%
       dplyr::summarise(total_well_cbs= sum(n)) %>%
       dplyr::mutate(rpm= total_well_cbs/10^6,
@@ -101,7 +101,7 @@ QC_images = function(annotated_counts, filtered_counts, normalized_counts= NA,
   
   ## Distribution of included and excluded reads ----
   distrib_fc= annotated_counts %>% dplyr::filter(n > 1, !is.na(pcr_plate), !is.na(pcr_well)) %>%
-    ggplot(aes(x= log10(n), fill= project_code)) +
+    ggplot(aes(x= log10(n), fill= expected_read)) +
     geom_histogram(position='identity', alpha=0.5) +
     geom_vline(xintercept= log10(count_threshold), linetype=2) +
     facet_wrap(~pcr_plate, scales='free') +
@@ -114,7 +114,7 @@ QC_images = function(annotated_counts, filtered_counts, normalized_counts= NA,
   
   ## In set/out set reads by well ----
   print('generating in set/out set figures')
-  idx_pairs= annotated_counts %>% dplyr::mutate(in_set= ifelse(!is.na(project_code), T, F)) %>%
+  idx_pairs= annotated_counts %>% dplyr::mutate(in_set= ifelse(expected_read, T, F)) %>%
     dplyr::group_by(index_1, index_2, pcr_plate, pcr_well, in_set) %>% 
     dplyr::summarise(sum_n= sum(n, na.rm=T)) %>% dplyr::ungroup() %>%
     dplyr::group_by(index_1, index_2) %>% 
@@ -214,9 +214,8 @@ QC_images = function(annotated_counts, filtered_counts, normalized_counts= NA,
   recurring_low_cl %>% write.csv(file= paste(out, 'recurring_low_cl.csv', sep='/'), row.names=F)
   #
   ## Contaminants ----
-  # relies on project_code being filled out
   contams= annotated_counts %>% 
-    dplyr::filter(!is.na(pcr_plate), !is.na(pcr_well), is.na(project_code), !is.na(CCLE_name) | !is.na(Name)) %>%
+    dplyr::filter(!is.na(pcr_plate), !is.na(pcr_well), expected_read==F, !is.na(CCLE_name) | !is.na(Name)) %>%
     dplyr::mutate(barcode_id= ifelse(is.na(CCLE_name), Name, CCLE_name)) %>%
     dplyr::group_by(forward_read_cl_barcode, barcode_id) %>% 
     dplyr::summarise(num_wells= n(), median_n=median(n), max_n= max(n)) %>% ungroup() %>%

--- a/R/QC_images.R
+++ b/R/QC_images.R
@@ -22,7 +22,7 @@
 #' @param count_threshold - threshold for low counts
 #' @return - NA, QC images are written out to the specified folder
 #' @export
-QC_images = function(annotated_counts, filtered_counts, normalized_counts= NA,
+QC_images = function(sample_meta, annotated_counts, filtered_counts, normalized_counts= NA,
                      CB_meta, cell_set_meta, out = NA, sig_cols, count_col_name= 'normalized_n',
                      count_threshold= 40) {
   if(is.na(out)) {

--- a/R/collapse_counts.R
+++ b/R/collapse_counts.R
@@ -7,17 +7,17 @@
 #'  @export 
 collapse_counts = function(l2fc) {
   collapsed_counts = l2fc %>% 
-    dplyr::filter(control_pass_QC, is.na(flag)) %>% 
+    dplyr::filter(is.na(counts_flag)) %>% 
     dplyr::group_by_at(setdiff(names(.), c('bio_rep', 'mean_n','mean_normalized_n', 'num_tech_reps', 'control_median_n',
                                            'control_median_normalized_n', 'control_mad_sqrtN', 'num_ctrl_bio_reps', 
-                                           'control_pass_QC','l2fc', 'flag'))) %>% 
+                                           'control_MAD_QC','l2fc', 'counts_flag'))) %>% 
     dplyr::summarise(trt_median_n= median(mean_n), trt_median_normalized_n= median(mean_normalized_n),
                      trt_mad_sqrtN= mad(log2(mean_normalized_n)) / sqrt(dplyr::n()),
                      median_l2fc= median(l2fc), num_bio_reps= dplyr::n()) %>% 
     dplyr::ungroup() %>% 
-    dplyr::mutate(trt_pass_QC= ifelse(trt_mad_sqrtN > 0.5/log10(2), F, T)) %>% # New: adjusted cut off to log2
+    dplyr::mutate(trt_MAD_QC= ifelse(trt_mad_sqrtN > 0.5/log10(2), F, T)) %>% # New: adjusted cut off to log2
     dplyr::relocate(trt_median_n, trt_median_normalized_n, trt_mad_sqrtN, 
-                    num_bio_reps, median_l2fc, trt_pass_QC, .after=last_col())
+                    num_bio_reps, median_l2fc, trt_MAD_QC, .after=last_col())
   
   return(collapsed_counts)
 }

--- a/R/collapse_counts.R
+++ b/R/collapse_counts.R
@@ -7,16 +7,17 @@
 #'  @export 
 collapse_counts = function(l2fc) {
   collapsed_counts = l2fc %>% 
-    dplyr::filter(control_pass_QC) %>% 
+    dplyr::filter(control_pass_QC, is.na(flag)) %>% 
     dplyr::group_by_at(setdiff(names(.), c('bio_rep', 'mean_n','mean_normalized_n', 'num_tech_reps', 'control_median_n',
                                            'control_median_normalized_n', 'control_mad_sqrtN', 'num_ctrl_bio_reps', 
                                            'control_pass_QC','l2fc', 'flag'))) %>% 
-    dplyr::summarise(trt_median_normalized_n= median(mean_normalized_n),
-                     median_l2fc= median(l2fc), num_bio_reps= n(),
-                     trt_mad_sqrtN= mad(log2(mean_normalized_n)) / sqrt(dplyr::n())) %>% 
+    dplyr::summarise(trt_median_n= median(mean_n), trt_median_normalized_n= median(mean_normalized_n),
+                     trt_mad_sqrtN= mad(log2(mean_normalized_n)) / sqrt(dplyr::n()),
+                     median_l2fc= median(l2fc), num_bio_reps= dplyr::n()) %>% 
     dplyr::ungroup() %>% 
     dplyr::mutate(trt_pass_QC= ifelse(trt_mad_sqrtN > 0.5/log10(2), F, T)) %>% # New: adjusted cut off to log2
-    dplyr::relocate(trt_median_normalized_n, trt_mad_sqrtN, num_bio_reps, median_l2fc, trt_pass_QC, .after=last_col())
+    dplyr::relocate(trt_median_n, trt_median_normalized_n, trt_mad_sqrtN, 
+                    num_bio_reps, median_l2fc, trt_pass_QC, .after=last_col())
   
   return(collapsed_counts)
 }

--- a/R/collapse_counts.R
+++ b/R/collapse_counts.R
@@ -8,9 +8,9 @@
 collapse_counts = function(l2fc) {
   collapsed_counts = l2fc %>% 
     dplyr::filter(control_pass_QC) %>% 
-    dplyr::group_by_at(setdiff(names(.), c('bio_rep', 'mean_normalized_n', 'num_tech_reps', 
-                                           'control_median_normalized_n', 'control_mad_sqrtN', 'num_ctrl_bio_reps', 'control_pass_QC',
-                                           'l2fc'))) %>% 
+    dplyr::group_by_at(setdiff(names(.), c('bio_rep', 'mean_n','mean_normalized_n', 'num_tech_reps', 'control_median_n',
+                                           'control_median_normalized_n', 'control_mad_sqrtN', 'num_ctrl_bio_reps', 
+                                           'control_pass_QC','l2fc', 'flag'))) %>% 
     dplyr::summarise(trt_median_normalized_n= median(mean_normalized_n),
                      median_l2fc= median(l2fc), num_bio_reps= n(),
                      trt_mad_sqrtN= mad(log2(mean_normalized_n)) / sqrt(dplyr::n())) %>% 

--- a/R/compute_l2fc.R
+++ b/R/compute_l2fc.R
@@ -31,11 +31,11 @@ compute_l2fc = function(normalized_counts,
   collapsed_tech_rep= normalized_counts %>%
     dplyr::filter(!(trt_type %in% c("empty", "", "CB_only")) & !is.na(trt_type), !is.na(CCLE_name)) %>%
     dplyr::group_by_at(setdiff(names(.), c('pcr_plate','pcr_well', 'Name', 'log2_dose', 'cb_intercept',
-                                           'profile_id', 'tech_rep', 'n', 'log2_np1', 'normalized_n', 'log2_normalized_n',
+                                           'profile_id', 'tech_rep', 'n', 'log2_n', 'normalized_n', 'log2_normalized_n',
                                            'flag', count_col_name))) %>% 
     dplyr::summarise(mean_n= mean(n),
                      mean_normalized_n = mean(!!rlang::sym(count_col_name)), 
-                     num_tech_reps= n()) %>% 
+                     num_tech_reps= dplyr::n()) %>% 
     dplyr::ungroup()
   
   # collapse controls
@@ -45,7 +45,7 @@ compute_l2fc = function(normalized_counts,
     dplyr::summarise(control_median_n= median(mean_n),
                      control_median_normalized_n = median(mean_normalized_n),
                      control_mad_sqrtN = mad(log2(mean_normalized_n))/sqrt(dplyr::n()),
-                     num_ctrl_bio_reps = n()) %>% 
+                     num_ctrl_bio_reps = dplyr::n()) %>% 
     dplyr::ungroup() %>% 
     dplyr::mutate(control_pass_QC = ifelse(control_mad_sqrtN > 0.5/log10(2), F, T)) # New: adjusted cut off to log2
   

--- a/R/compute_l2fc.R
+++ b/R/compute_l2fc.R
@@ -12,6 +12,7 @@
 #'                    cell_set,day by default.
 #' @param count_col_name - a string containing the name of the column to use as counts to calculate l2fc values. 
 #'          Generally normalized_n if running on normalied_counts or n if running on filtered_counts
+#' @param count_threshold - threshold for determining low counts, defaults to 40.
 #' @return - l2fc data.frame with l2fc column
 #' @export
 compute_l2fc = function(normalized_counts, 
@@ -47,7 +48,7 @@ compute_l2fc = function(normalized_counts,
                      control_mad_sqrtN = mad(log2(mean_normalized_n))/sqrt(dplyr::n()),
                      num_ctrl_bio_reps = dplyr::n()) %>% 
     dplyr::ungroup() %>% 
-    dplyr::mutate(control_pass_QC = ifelse(control_mad_sqrtN > 0.5/log10(2), F, T)) # New: adjusted cut off to log2
+    dplyr::mutate(control_MAD_QC = ifelse(control_mad_sqrtN > 0.5/log10(2), F, T)) # New: adjusted cut off to log2
   
   if(nrow(controls)==0) {
     print("No samples found for indicated control type.")
@@ -57,7 +58,7 @@ compute_l2fc = function(normalized_counts,
   l2fc= collapsed_tech_rep %>% dplyr::filter(!trt_type %in% c(control_type, 'day_0')) %>% 
     merge(controls, by= c('project_code',"CCLE_name", "DepMap_ID", "prism_cell_set", ctrl_cols), all.x=T, all.y=T) %>%
     dplyr::mutate(l2fc= log2(mean_normalized_n/control_median_normalized_n),
-                  flag= ifelse(control_median_n < count_threshold, paste0('negcon<', count_threshold), NA)) %>%
+                  counts_flag= ifelse(control_median_n < count_threshold, paste0('negcon<', count_threshold), NA)) %>%
     dplyr::relocate(project_code, CCLE_name, DepMap_ID, prism_cell_set, trt_type, control_barcodes, sig_id, bio_rep)
   
   return(l2fc)

--- a/R/compute_l2fc.R
+++ b/R/compute_l2fc.R
@@ -18,7 +18,7 @@ compute_l2fc = function(normalized_counts,
                         control_type = "negcon",
                         sig_cols=c('cell_set','treatment','dose','dose_unit','day'),
                         ctrl_cols= c('cell_set', 'day'), # will probably be a subset of sig_cols
-                        count_col_name="normalized_n") {
+                        count_col_name="normalized_n", count_threshold= 40) {
   
   if(!all(ctrl_cols %in% sig_cols)) {
     print("Control columns are not a subset of sig columns.") # new
@@ -31,9 +31,10 @@ compute_l2fc = function(normalized_counts,
   collapsed_tech_rep= normalized_counts %>%
     dplyr::filter(!(trt_type %in% c("empty", "", "CB_only")) & !is.na(trt_type), !is.na(CCLE_name)) %>%
     dplyr::group_by_at(setdiff(names(.), c('pcr_plate','pcr_well', 'Name', 'log2_dose', 'cb_intercept',
-                                           'profile_id', 'tech_rep', 'n', 'log2_n', 'normalized_n', 'log2_normalized_n',
+                                           'profile_id', 'tech_rep', 'n', 'log2_np1', 'normalized_n', 'log2_normalized_n',
                                            'flag', count_col_name))) %>% 
-    dplyr::summarise(mean_normalized_n = mean(!! rlang::sym(count_col_name)), 
+    dplyr::summarise(mean_n= mean(n),
+                     mean_normalized_n = mean(!!rlang::sym(count_col_name)), 
                      num_tech_reps= n()) %>% 
     dplyr::ungroup()
   
@@ -41,11 +42,12 @@ compute_l2fc = function(normalized_counts,
   controls= collapsed_tech_rep %>% 
     dplyr::filter(trt_type==control_type) %>% 
     dplyr::group_by_at(c('project_code', 'CCLE_name', 'DepMap_ID', 'prism_cell_set', ctrl_cols)) %>% 
-    dplyr::summarise(control_median_normalized_n = median(mean_normalized_n),
+    dplyr::summarise(control_median_n= median(mean_n),
+                     control_median_normalized_n = median(mean_normalized_n),
                      control_mad_sqrtN = mad(log2(mean_normalized_n))/sqrt(dplyr::n()),
                      num_ctrl_bio_reps = n()) %>% 
     dplyr::ungroup() %>% 
-    dplyr::mutate(control_pass_QC = ifelse(control_mad_sqrtN > 0.5/log10(2), F, T)) #%>% # New: adjusted cut off to log2
+    dplyr::mutate(control_pass_QC = ifelse(control_mad_sqrtN > 0.5/log10(2), F, T)) # New: adjusted cut off to log2
   
   if(nrow(controls)==0) {
     print("No samples found for indicated control type.")
@@ -54,7 +56,8 @@ compute_l2fc = function(normalized_counts,
   
   l2fc= collapsed_tech_rep %>% dplyr::filter(!trt_type %in% c(control_type, 'day_0')) %>% 
     merge(controls, by= c('project_code',"CCLE_name", "DepMap_ID", "prism_cell_set", ctrl_cols), all.x=T, all.y=T) %>%
-    dplyr::mutate(l2fc= log2(mean_normalized_n/control_median_normalized_n)) %>%
+    dplyr::mutate(l2fc= log2(mean_normalized_n/control_median_normalized_n),
+                  flag= ifelse(control_median_n < count_threshold, paste0('negcon<', count_threshold), NA)) %>%
     dplyr::relocate(project_code, CCLE_name, DepMap_ID, prism_cell_set, trt_type, control_barcodes, sig_id, bio_rep)
   
   return(l2fc)

--- a/R/filter_raw_reads.R
+++ b/R/filter_raw_reads.R
@@ -4,7 +4,8 @@
 #' using the given metadata. QC metrics are returned as a data.frame
 #'
 #' @param raw_counts - an unfiltered counts table
-#' @param sample_meta - the sample metadata for the particular experiment. Must follow the given set of guidelines for metadata
+#' @param sample_meta - the sample metadata for the particular experiment. Must follow the given set of 
+#'                      guidelines for metadata
 #' @param cell_line_meta - master metadata of cell lines
 #' @param cell_set_meta - master metdata of cell sets and their contents
 #' @param CB_meta - master metdata of control barcodes, their sequences, and their doses
@@ -50,8 +51,7 @@ filter_raw_reads = function(
   #index_to_well= sample_meta %>% dplyr::distinct(pick(c('IndexBarcode1', 'IndexBarcode2', 'pcr_plate', 'pcr_well')))
   sample_meta$profile_id= do.call(paste,c(sample_meta[id_cols], sep=':'))
   template= sample_meta %>% merge(cell_set_meta, by='cell_set', all.x=T) %>%
-    dplyr::mutate(expected_read= T,
-                  members= ifelse(is.na(members), str_split(cell_set, ';'), str_split(members, ';'))) %>% 
+    dplyr::mutate(members= ifelse(is.na(members), str_split(cell_set, ';'), str_split(members, ';'))) %>% 
     unnest(cols=c(members)) %>%
     merge(cell_line_meta, by.x= 'members', by.y= 'LUA', all.x= T)
   
@@ -69,7 +69,7 @@ filter_raw_reads = function(
     merge(cell_line_meta, by.x="forward_read_cl_barcode", by.y="Sequence", all.x=T) %>%
     merge(CB_meta, by.x="forward_read_cl_barcode", by.y="Sequence", all.x=T) %>%
     merge(sample_meta, by.x= c('index_1', 'index_2'), by.y= c('IndexBarcode1', 'IndexBarcode2'), all.x=T) %>%
-    merge(template, 
+    merge(template %>% dplyr::mutate(expected_read= T), 
           by.x= c('index_1', 'index_2', 'forward_read_cl_barcode', intersect(colnames(template), colnames(.))), 
           by.y= c('IndexBarcode1', 'IndexBarcode2', 'Sequence', intersect(colnames(template), colnames(.))),
           all.x=T, all.y=T) %>% 

--- a/R/filter_raw_reads.R
+++ b/R/filter_raw_reads.R
@@ -47,17 +47,18 @@ filter_raw_reads = function(
   qc_table = data.frame(cell_line_purity=cell_line_purity, index_purity = index_purity)
   
   # make template of expected reads
-  index_to_well= sample_meta %>% dplyr::distinct(pick(c('IndexBarcode1', 'IndexBarcode2', 'pcr_plate', 'pcr_well')))
+  #index_to_well= sample_meta %>% dplyr::distinct(pick(c('IndexBarcode1', 'IndexBarcode2', 'pcr_plate', 'pcr_well')))
   sample_meta$profile_id= do.call(paste,c(sample_meta[id_cols], sep=':'))
   template= sample_meta %>% merge(cell_set_meta, by='cell_set', all.x=T) %>%
-    dplyr::mutate(members= ifelse(is.na(members), str_split(cell_set, ';'), str_split(members, ';'))) %>% 
+    dplyr::mutate(expected_read= T,
+                  members= ifelse(is.na(members), str_split(cell_set, ';'), str_split(members, ';'))) %>% 
     unnest(cols=c(members)) %>%
     merge(cell_line_meta, by.x= 'members', by.y= 'LUA', all.x= T)
   
   # check for control barcodes and add them to the template
   if ('Y' %in% sample_meta$control_barcodes | T %in% sample_meta$control_barcodes) {
     cb_template= sample_meta %>% dplyr::filter(control_barcodes %in% c('Y', 'T', T)) %>%
-      dplyr::mutate(joiner = 'temp') %>%
+      dplyr::mutate(joiner= 'temp') %>%
       merge(CB_meta %>% dplyr::mutate(joiner= 'temp'), by='joiner') %>% dplyr::select(-joiner)
     template= plyr::rbind.fill(template, cb_template)
   }
@@ -67,18 +68,19 @@ filter_raw_reads = function(
   annotated_counts= raw_counts %>%
     merge(cell_line_meta, by.x="forward_read_cl_barcode", by.y="Sequence", all.x=T) %>%
     merge(CB_meta, by.x="forward_read_cl_barcode", by.y="Sequence", all.x=T) %>%
-    merge(index_to_well, by.x= c('index_1', 'index_2'), by.y= c('IndexBarcode1', 'IndexBarcode2'), all.x=T) %>%
+    merge(sample_meta, by.x= c('index_1', 'index_2'), by.y= c('IndexBarcode1', 'IndexBarcode2'), all.x=T) %>%
     merge(template, 
           by.x= c('index_1', 'index_2', 'forward_read_cl_barcode', intersect(colnames(template), colnames(.))), 
           by.y= c('IndexBarcode1', 'IndexBarcode2', 'Sequence', intersect(colnames(template), colnames(.))),
           all.x=T, all.y=T) %>% 
-    dplyr::mutate(n= replace_na(n, 0))
+    dplyr::mutate(n= replace_na(n, 0),
+                  expected_read= replace_na(expected_read, F))
   
   # filtered counts
   print("Filtering reads ...")
   filt_cols= c('project_code', 'pcr_plate', 'pcr_well', 'CCLE_name', 'DepMap_ID', 'prism_cell_set',
                'control_barcodes', 'Name', 'log2_dose','profile_id', 'trt_type')
-  filtered_counts= annotated_counts %>% dplyr::filter(!is.na(project_code)) %>%
+  filtered_counts= annotated_counts %>% dplyr::filter(expected_read) %>%
     dplyr::select(any_of(c(filt_cols, id_cols, 'n'))) %>%
     dplyr::mutate(flag= ifelse(n==0, 'Missing', NA),
                   flag= ifelse(n!=0 & n < count_threshold, 'low counts', flag))

--- a/R/normalize.R
+++ b/R/normalize.R
@@ -15,12 +15,11 @@
 normalize <- function(X, barcodes) {
   if (!('log2_n' %in% colnames(X)) & 
       ('n' %in% colnames(X))) {
-    X <- X %>% dplyr::mutate(log2_n = log2(n))
+    X <- X %>% dplyr::mutate(log2_n = log2(n+1))
   }
 
   normalized <- X %>%
-    dplyr::filter(!(trt_type %in% c("empty", "", "CB_only")) & !is.na(trt_type), 
-                  control_barcodes==T, !grepl('Missing', flag)) %>% 
+    dplyr::filter(!(trt_type %in% c("empty", "", "CB_only")) & !is.na(trt_type), control_barcodes==T) %>% 
     dplyr::group_by(profile_id) %>%
     # filter out profiles with 4 or fewer detected control barcodes
     dplyr::mutate(num_cbs= length(unique(na.omit(Name)))) %>% dplyr::filter(num_cbs > 4) %>%

--- a/scripts/compute_l2fc.R
+++ b/scripts/compute_l2fc.R
@@ -23,6 +23,7 @@ parser$add_argument("--ctrl_cols", default="cell_set,day",
                     help = "columns used to collapse controls to generate l2fc")
 parser$add_argument("-ccn", "--count_col_name", default="normalized_n", 
                     help = "column containing counts with which to calculate l2fc")
+parser$add_argument("--count_threshold", default= 40, help = "Low counts threshold")
 parser$add_argument("-o","--out", default=getwd(), help = "Output path. Default is working directory")
 
 # get command line options, if help option encountered print help and exit
@@ -33,9 +34,10 @@ normalized_counts = read.csv(args$normalized_counts)
 sig_cols = unlist(strsplit(args$sig_cols, ","))
 ctrl_cols = unlist(strsplit(args$ctrl_cols, ","))
 count_col_name = args$count_col_name
+count_threshold= args$count_threshold
 
 print("computing log-fold change")
-l2fc = compute_l2fc(normalized_counts, control_type, sig_cols, ctrl_cols, count_col_name)
+l2fc = compute_l2fc(normalized_counts, control_type, sig_cols, ctrl_cols, count_col_name, count_threshold)
 
 l2fc_out = paste(args$out, "l2fc.csv", sep="/")
 write.csv(l2fc, l2fc_out, row.names=F, quote=F)

--- a/scripts/filteredCounts_QC.R
+++ b/scripts/filteredCounts_QC.R
@@ -62,7 +62,8 @@ count_threshold = args$count_threshold
 print("generating filtered counts QC images")
 #QC_images(annotated_counts, filtered_counts, normalized_counts,
 #          CB_meta, cell_set_meta, args$out, sig_cols, count_col_name)
-QC_images(annotated_counts= annotated_counts, 
+QC_images(sample_meta= sample_meta,
+          annotated_counts= annotated_counts, 
           filtered_counts= filtered_counts,
           normalized_counts= normalized_counts,
           CB_meta= CB_meta, cell_set_meta= cell_set_meta, 

--- a/scripts/filteredCounts_QC.R
+++ b/scripts/filteredCounts_QC.R
@@ -58,5 +58,18 @@ count_threshold = args$count_threshold
 print("generating filtered counts QC images")
 #QC_images(annotated_counts, filtered_counts, normalized_counts,
 #          CB_meta, cell_set_meta, args$out, sig_cols, count_col_name)
-QC_images(annotated_counts, filtered_counts, normalized_counts,
-          CB_meta, cell_set_meta, out= args$out, sig_cols, count_col_name, count_threshold)
+
+if(file.exists(args$normalized_counts)) {
+  QC_images(annotated_counts= annotated_counts, 
+            filtered_counts= filtered_counts,
+            normalized_counts= normalized_counts,
+            CB_meta= CB_meta, cell_set_meta= cell_set_meta, 
+            out= args$out, 
+            sig_cols= sig_cols, count_col_name= count_col_name, count_threshold= count_threshold)
+} else {
+  QC_images(annotated_counts= annotated_counts, 
+            filtered_counts= filtered_counts,
+            CB_meta= CB_meta, cell_set_meta= cell_set_meta, 
+            out= args$out, 
+            sig_cols= sig_cols, count_col_name= count_col_name, count_threshold= count_threshold)
+}

--- a/scripts/filteredCounts_QC.R
+++ b/scripts/filteredCounts_QC.R
@@ -47,7 +47,11 @@ if (args$out == ""){
 
 annotated_counts= read.csv(args$annotated_counts)
 filtered_counts = read.csv(args$filtered_counts)
-normalized_counts= read.csv(args$normalized_counts)
+if(file.exists(args$normalized_counts)) {
+  normalized_counts= read.csv(args$normalized_counts)
+} else {
+  normalized_counts= NA
+}
 CB_meta= read.csv(args$CB_meta)
 cell_set_meta = read.csv(args$cell_set_meta)
 sig_cols = unlist(strsplit(args$sig_cols, ","))
@@ -58,18 +62,9 @@ count_threshold = args$count_threshold
 print("generating filtered counts QC images")
 #QC_images(annotated_counts, filtered_counts, normalized_counts,
 #          CB_meta, cell_set_meta, args$out, sig_cols, count_col_name)
-
-if(file.exists(args$normalized_counts)) {
-  QC_images(annotated_counts= annotated_counts, 
-            filtered_counts= filtered_counts,
-            normalized_counts= normalized_counts,
-            CB_meta= CB_meta, cell_set_meta= cell_set_meta, 
-            out= args$out, 
-            sig_cols= sig_cols, count_col_name= count_col_name, count_threshold= count_threshold)
-} else {
-  QC_images(annotated_counts= annotated_counts, 
-            filtered_counts= filtered_counts,
-            CB_meta= CB_meta, cell_set_meta= cell_set_meta, 
-            out= args$out, 
-            sig_cols= sig_cols, count_col_name= count_col_name, count_threshold= count_threshold)
-}
+QC_images(annotated_counts= annotated_counts, 
+          filtered_counts= filtered_counts,
+          normalized_counts= normalized_counts,
+          CB_meta= CB_meta, cell_set_meta= cell_set_meta, 
+          out= args$out, 
+          sig_cols= sig_cols, count_col_name= count_col_name, count_threshold= count_threshold)


### PR DESCRIPTION
Changes:

Filter_raw_reads

- Added all metadata information associated with a well to each read.
- Created a column “expected_read” with values of True or False in annotated counts to distinguish between expected barcodes and contaminants.

Normalize

- Added a pseudo count to all reads
- Applied normalizations to all reads.

Compute_l2fc

- Added a new parameter “count_threshold” which defaults to 40. 
- Added columns “mean_n” and “control_median_n” for collapsed raw count values.
- Added a “flag” column that identifies cell lines in wells where the collapsed raw counts in the negative control are less than a threshold.

Collapse_counts

- Updated filter to exclude flagged cell lines.
- Updated group_by to work with new compute_l2fc outputs.
- Added column “trt_median_n” for collapsed raw values.

QC images

- Made normalized_counts optional
