### PR TITLE
Cell db metadata

### DIFF
--- a/scripts/filter_counts.R
+++ b/scripts/filter_counts.R
@@ -138,16 +138,18 @@ filtered_counts = filter_raw_reads(
   reverse_index2=args$reverse_index2
 )
 
-# Pulling pool_id
-unique_cell_sets <- unique(sample_meta$cell_set[sample_meta$cell_set != ""])
-assay_pools_df <- assay_pools_df[assay_pools_df$davepool_id %in% unique_cell_sets,] %>% 
-  select(pool_id, ccle_name, davepool_id, depmap_id, culture)
-
-filtered_counts$filtered_counts = filtered_counts$filtered_counts %>% 
-  merge(assay_pools_df, by.x=c("CCLE_name", "cell_set", "DepMap_ID"), by.y=c("ccle_name", "davepool_id", "depmap_id"), all.x=T) 
-
-filtered_counts$annotated_counts = filtered_counts$annotated_counts %>% 
-  merge(assay_pools_df, by.x=c("CCLE_name", "cell_set", "DepMap_ID"), by.y=c("ccle_name", "davepool_id", "depmap_id"), all.x=T) 
+# Pulling pool_id and culture when db_flag is passed
+if (args$db_flag) {
+  unique_cell_sets <- unique(sample_meta$cell_set[sample_meta$cell_set != ""])
+  assay_pools_df <- assay_pools_df[assay_pools_df$davepool_id %in% unique_cell_sets,] %>% 
+    select(pool_id, ccle_name, davepool_id, depmap_id, culture)
+  
+  filtered_counts$filtered_counts = filtered_counts$filtered_counts %>% 
+    merge(assay_pools_df, by.x=c("CCLE_name", "cell_set", "DepMap_ID"), by.y=c("ccle_name", "davepool_id", "depmap_id"), all.x=T) 
+  
+  filtered_counts$annotated_counts = filtered_counts$annotated_counts %>% 
+    merge(assay_pools_df, by.x=c("CCLE_name", "cell_set", "DepMap_ID"), by.y=c("ccle_name", "davepool_id", "depmap_id"), all.x=T) 
+}
 
 # Write out module outputs
 qc_table = filtered_counts$qc_table

--- a/scripts/filter_counts.R
+++ b/scripts/filter_counts.R
@@ -97,8 +97,13 @@ if (args$db_flag) {
   cell_sets <- create_cell_set_meta(sample_meta, cell_sets_df, cell_pools_df)
   cell_set_meta <- cell_sets[[1]]
   failed_cell_sets <- cell_sets[[2]]
-  # Add failure code if failed cell sets not empty
   
+  # Fail if failed cell sets not empty
+  if (nrow(failed_cell_sets) != 0){
+    print(failed_cell_sets)
+    stop("The sample_meta contains cell sets not registered in CellDB.")
+  }
+
   # Writing out cell_line_meta - may be necessary for downstream SUSHI?
   cell_line_out_file = paste(args$out, 'cell_line_meta.csv', sep='/')
   print(paste("writing cell_line_meta to: ", cell_line_out_file))
@@ -142,7 +147,7 @@ filtered_counts = filter_raw_reads(
 if (args$db_flag) {
   unique_cell_sets <- unique(sample_meta$cell_set[sample_meta$cell_set != ""])
   assay_pools_df <- assay_pools_df[assay_pools_df$davepool_id %in% unique_cell_sets,] %>% 
-    select(pool_id, ccle_name, davepool_id, depmap_id, culture)
+    select(pool_id, ccle_name, davepool_id, depmap_id)
   
   filtered_counts$filtered_counts = filtered_counts$filtered_counts %>% 
     merge(assay_pools_df, by.x=c("CCLE_name", "cell_set", "DepMap_ID"), by.y=c("ccle_name", "davepool_id", "depmap_id"), all.x=T) 

--- a/scripts/filter_counts.R
+++ b/scripts/filter_counts.R
@@ -54,7 +54,7 @@ parser$add_argument("--CB_meta", default="../metadata/CB_meta.csv", help = "Cont
 parser$add_argument("--id_cols", default="cell_set,treatment,dose,dose_unit,day,bio_rep,tech_rep",
     help = "Columns used to generate profile ids, comma-separated colnames from --sample_meta")
 parser$add_argument("--count_threshold", default= 40, help = "Low counts threshold")
-parser$add_argument("--reverse_index2", action="store_true", default=FALSE, help = "Reverse complement of index 2 for NovaSeq")
+parser$add_argument("--reverse_index2", action="store_true", default=TRUE, help = "Reverse complement of index 2 for NovaSeq")
 
 # NEW
 parser$add_argument("--api_url", default="https://api.clue.io/api/cell_sets", help = "Default API URL to CellDB cell sets")
@@ -70,10 +70,13 @@ if (args$out == ""){
 }
 #print_args(args)
 
-CB_meta = read.csv(args$CB_meta)
-sample_meta = read.csv(args$sample_meta)
-raw_counts = read.csv(args$raw_counts)
+# CB_meta = read.csv(args$CB_meta)
+# sample_meta = read.csv(args$sample_meta)
+# raw_counts = read.csv(args$raw_counts)
 
+CB_meta = read.csv("/Users/naim/Documents/Work/Troubleshooting/SUSHI_Testing/metadata/CB_meta.csv")
+raw_counts = read.csv("/Users/naim/Documents/Work/Troubleshooting/SUSHI_Testing/EPS001_CellDB_01092023/raw_counts.csv")
+sample_meta = read.csv("/Users/naim/Documents/Work/Troubleshooting/SUSHI_Testing/EPS001_CellDB_01092023/sample_meta.csv")
 
 # Using CellDB, otherwise checking static files
 if (args$db_flag) {
@@ -90,6 +93,7 @@ if (args$db_flag) {
   cell_sets_df <- get_cell_api_info("https://api.clue.io/api/cell_sets", api_key)
   cell_pools_df <- get_cell_api_info("https://api.clue.io/api/assay_pools", api_key)
   cell_line_meta <- get_cell_api_info("https://api.clue.io/api/cell_lines", api_key)
+  assay_pool_meta <- get_cell_api_info("https://api.clue.io/api/cell_set_definition_files", api_key)
   cell_sets <- create_cell_set_meta(sample_meta)
   # Renaming columns to match expected naming from static files
   cell_line_meta <- cell_line_meta %>%

--- a/scripts/src/cellDB_metadata.R
+++ b/scripts/src/cellDB_metadata.R
@@ -71,6 +71,7 @@ get_cell_line_info <- function(all_LUAs) {
 
 create_cell_set_meta = function(sample_meta) {
   unique_cell_sets <- unique(sample_meta$cell_set[sample_meta$cell_set != ""])
+  cell_line_meta <- cell_line_meta[cell_line_meta$davepool_id %in% unique_cell_sets,]
   cell_set_meta <- data.frame(matrix(ncol = 2, nrow = length(unique_cell_sets)))
   columns <- c("cell_set", "members")
   colnames(cell_set_meta) <- columns
@@ -92,7 +93,7 @@ create_cell_set_meta = function(sample_meta) {
       if (cs[j] %in% cell_sets_df$name) {
         print(paste(cs[j], "is a cell set.")) 
         known_cell_sets = c(known_cell_sets, cs[j])
-        
+
         # Collecting and storing set LUA members   
         cs_members = get_LUAs_from_sets(cs[j])
         all_LUAs = append(all_LUAs, cs_members)
@@ -105,7 +106,7 @@ create_cell_set_meta = function(sample_meta) {
         pool_members = get_LUAs_from_pools(cs[j])
         all_LUAs = append(all_LUAs, pool_members)
         
-      } else if (cs[j] %in% cell_line_meta$lua){
+      } else if (cs[j] %in% cell_line_meta$LUA){
         print(paste(cs[j], "is a cell line")) 
         all_LUAs = append(all_LUAs, cs[j])
         known_cell_sets = c(known_cell_sets, cs[j])
@@ -134,5 +135,5 @@ create_cell_set_meta = function(sample_meta) {
     print("cell_set_meta is empty. One or more pieces of cell information within a cell set in the cell_set column of sample_meta was not found.")
   }
   
-  return(list(cell_set_meta, failed_sets))
+  return(list(cell_line_meta, cell_set_meta, failed_sets))
 }

--- a/scripts/src/cellDB_metadata.R
+++ b/scripts/src/cellDB_metadata.R
@@ -69,9 +69,8 @@ get_cell_line_info <- function(all_LUAs) {
   return(cell_lines_info)
 }
 
-create_cell_set_meta = function(sample_meta) {
+create_cell_set_meta = function(sample_meta, cell_sets_df, cell_pools_df, cell_line_meta) {
   unique_cell_sets <- unique(sample_meta$cell_set[sample_meta$cell_set != ""])
-  cell_line_meta <- cell_line_meta[cell_line_meta$davepool_id %in% unique_cell_sets,]
   cell_set_meta <- data.frame(matrix(ncol = 2, nrow = length(unique_cell_sets)))
   columns <- c("cell_set", "members")
   colnames(cell_set_meta) <- columns
@@ -130,10 +129,11 @@ create_cell_set_meta = function(sample_meta) {
       failed_sets <- c(failed_sets, chr_unique_cell_sets)
     }
   }
+  
   cell_set_meta <- na.omit(cell_set_meta)
   if (nrow(cell_set_meta) == 0) {
     print("cell_set_meta is empty. One or more pieces of cell information within a cell set in the cell_set column of sample_meta was not found.")
   }
   
-  return(list(cell_line_meta, cell_set_meta, failed_sets))
+  return(list(cell_set_meta, failed_sets))
 }

--- a/scripts/src/filter_raw_reads.R
+++ b/scripts/src/filter_raw_reads.R
@@ -86,8 +86,8 @@ filter_raw_reads = function(
   
   # filtered counts
   print("Filtering reads ...")
-  filt_cols= c('project_code', 'DepMap_ID', 'CCLE_name', 'pcr_plate', 'pcr_well', 'ccle_name', 'depmap_id', 'prism_cell_set',
-               'control_barcodes', 'Name', 'log2_dose','profile_id', 'trt_type')
+  filt_cols= c('project_code', 'DepMap_ID', 'CCLE_name', 'pcr_plate', 'pcr_well', 'ccle_name', 'depmap_id',
+               'control_barcodes', 'Name', 'log2_dose','profile_id', 'trt_type', 'culture','pool_id')
   filtered_counts= annotated_counts %>% dplyr::filter(expected_read) %>%
     dplyr::select(any_of(c(filt_cols, id_cols, 'n'))) %>%
     dplyr::mutate(flag= ifelse(n==0, 'Missing', NA),

--- a/scripts/src/filter_raw_reads.R
+++ b/scripts/src/filter_raw_reads.R
@@ -87,7 +87,7 @@ filter_raw_reads = function(
   # filtered counts
   print("Filtering reads ...")
   filt_cols= c('project_code', 'DepMap_ID', 'CCLE_name', 'pcr_plate', 'pcr_well', 'ccle_name', 'depmap_id',
-               'control_barcodes', 'Name', 'log2_dose','profile_id', 'trt_type', 'culture','pool_id')
+               'control_barcodes', 'Name', 'log2_dose','profile_id', 'trt_type','pool_id')
   filtered_counts= annotated_counts %>% dplyr::filter(expected_read) %>%
     dplyr::select(any_of(c(filt_cols, id_cols, 'n'))) %>%
     dplyr::mutate(flag= ifelse(n==0, 'Missing', NA),


### PR DESCRIPTION
Added code to use CellDB for metadata needs during filter_counts. Takes values in the cell_set column of sample_meta and identifies their corresponding set of LUAs using CellDB. Also adds two new columns during filter counts - pool_id and culture (equivalent to prism_cell_set). 

May need to consider how different types of possible cell set values will be handled (string of LUAs, concatenated string of pools, concatenated string of cell sets) when pulling the pool_id and culture values. Also need to consider how metadata that already contains a pool_id column will be handled.