### PR TITLE
[HOLD] Collapsing raw counts

### DIFF
--- a/R/QC_images.R
+++ b/R/QC_images.R
@@ -405,7 +405,7 @@ QC_images = function(sample_meta, raw_counts, annotated_counts, normalized_count
         filter(!is.na(CCLE_name),
                (!trt_type %in% c("empty", "", "CB_only")) & !is.na(trt_type)) %>% 
         mutate(plt_id= paste(sig_id, bio_rep, sep=':')) %>% 
-        dcast(CCLE_name~plt_id, value.var="mean_normalized_n") %>% 
+        reshape2::dcast(CCLE_name~plt_id, value.var="mean_normalized_n") %>% 
         column_to_rownames("CCLE_name") %>% 
         cor(use="pairwise.complete.obs")
       

--- a/R/QC_images.R
+++ b/R/QC_images.R
@@ -1,3 +1,32 @@
+#' Calculate index summaries
+#' 
+#' Generates some simple summaries for each unique index.
+#' 
+#' @param df A dataframe which must contain the column "n" which represents the count of a read.
+#' @param index_col The name of the column contain the index barcodes as a string. This column must be present in "df".
+#' @param valid_indices. A vector of all the valid indices for "index_col".
+#' @return A dataframe with the follow columns:
+#'         - index_col: String, The column containing the index barcodes.
+#'         - idx_n: Numeric, Number of reads associated with a specific index barcode.
+#'         - fraction: Numeric, "idx_n" divided by the total number of reads in the run.
+#'         - expected: Boolean, True if the index barcode is in "valid_indices" otherwise False.
+#'         - contains_n: Boolean, True if the index barcode contains "N" in its sequence, otherwise False.
+#'         - lv_dist: Numeric, Edit distance from a valid index barcode.
+#'         - ham_dist: Numeric, Hamming distance from a valid index barcode.
+get_index_summary= function(df, index_col, valid_indices) {
+  output_summary= df %>% dplyr::group_by(pick(all_of(index_col))) %>% 
+    dplyr::summarise(idx_n= sum(n)) %>% dplyr::ungroup() %>%
+    dplyr::mutate(fraction= round(idx_n/sum(idx_n), 5),
+                  expected= ifelse(.[[index_col]] %in% valid_indices, T, F),
+                  contains_n= ifelse(grepl('N', .[[index_col]]), T, F),
+                  lv_dist= apply(stringdist::stringdistmatrix(.[[index_col]], valid_indices, method="lv"), 
+                                 1, min),
+                  ham_dist= apply(stringdist::stringdistmatrix(.[[index_col]], valid_indices, method="hamming"), 
+                                  1, min)) %>%
+    dplyr::arrange(desc(fraction))
+  return(output_summary)
+}
+
 #'  QC_images
 #'
 #'  Takes in the metadata, raw counts, annotated counts, and normalized counts to generate some QC images.
@@ -48,32 +77,25 @@ QC_images = function(sample_meta, raw_counts, annotated_counts, normalized_count
   
   # Sequencing QCs ____________________ ----
   ## Index count summaries ----
-  print("generating index counts tables")
-  # pull unique indices.
-  expected_index1= unique(sample_meta$IndexBarcode1)
-  expected_index2= unique(sample_meta$IndexBarcode2)
+  print("Generating index counts tables")
+  # Check that "IndexBarcode1" and "index_1" columns are present.
+  # If so, calculate index summary and write out.
+  if('IndexBarcode1' %in% colnames(sample_meta) & 'index_1' %in% colnames(raw_counts)) {
+    expected_index1= unique(sample_meta$IndexBarcode1)
+    index1_counts= get_index_summary(raw_counts, 'index_1', expected_index1)
+    index1_counts %>% write.csv(file= paste(out, 'index1_counts.csv', sep='/'), row.names=F)
+  } else {
+    print('Columns IndexBarcode1 and/or index_1 are not detected. Skipping index 1 summaries ...')
+  }
   
-  index1_counts= raw_counts %>% dplyr::group_by(index_1) %>%
-    dplyr::summarise(idx_n= sum(n, na.rm= T)) %>% dplyr::ungroup() %>%
-    dplyr::mutate(fraction= round(idx_n/sum(idx_n), 5),
-                  expected= ifelse(index_1 %in% expected_index1, T, F),
-                  contains_n= ifelse(grepl('N', index_1), T, F),
-                  lv_dist= apply(stringdist::stringdistmatrix(index_1, expected_index1, method="lv"), 1, min),
-                  ham_dist= apply(stringdist::stringdistmatrix(index_1, expected_index1, method="hamming"), 1, min)) %>%
-    dplyr::arrange(desc(fraction))
-  index2_counts= raw_counts %>% dplyr::group_by(index_2) %>%
-    dplyr::summarise(idx_n= sum(n, na.rm= T)) %>% dplyr::ungroup() %>%
-    dplyr::mutate(fraction= round(idx_n/sum(idx_n), 5),
-                  expected= ifelse(index_2 %in% expected_index2, T, F),
-                  contains_n= ifelse(grepl('N', index_2), T, F),
-                  lv_dist= apply(stringdist::stringdistmatrix(index_2, expected_index2, method="lv"), 1, min),
-                  ham_dist= apply(stringdist::stringdistmatrix(index_2, expected_index2, method="hamming"), 1, min)) %>%
-    dplyr::arrange(desc(fraction))
-  
-  # export and remove
-  index1_counts %>% write.csv(file= paste(out, 'index1_counts.csv', sep='/'), row.names=F)
-  index2_counts %>% write.csv(file= paste(out, 'index2_counts.csv', sep='/'), row.names=F)
-  rm(expected_index1, index1_counts, expected_index2, index2_counts)
+  # Do the same for index 2.
+  if('IndexBarcode2' %in% colnames(sample_meta) & 'index_2' %in% colnames(raw_counts)) {
+    expected_index2= unique(sample_meta$IndexBarcode2)
+    index2_counts= get_index_summary(raw_counts, 'index_2', expected_index2)
+    index2_counts %>% write.csv(file= paste(out, 'index2_counts.csv', sep='/'), row.names=F)
+  } else {
+    print('Columns IndexBarcode2 and/or index_2 are not detected. Skipping index 2 summaries ...')
+  }
   
   ## Total counts ----
   print("generating total_counts image")
@@ -87,7 +109,7 @@ QC_images = function(sample_meta, raw_counts, annotated_counts, normalized_count
     geom_col(aes(x=sample_id, y=total_counts, fill=type), alpha=0.75, position='identity') +
     geom_hline(yintercept= 10^4, linetype=2) + 
     facet_wrap(~pcr_plate, scale= 'free_x') +
-    labs(x="", y="total counts", fill="", title= 'Raw counts - unstacked') + theme_bw() +
+    labs(x="PCR location", y="total counts", fill="", title= 'Raw counts - unstacked') + theme_bw() +
     theme(axis.text.x = element_text(angle=70, hjust=1, size=5)) 
   
   pdf(file=paste(out, "total_counts.pdf", sep="/"),
@@ -101,14 +123,14 @@ QC_images = function(sample_meta, raw_counts, annotated_counts, normalized_count
   print("generating cell_lines_present image")
   recovery= annotated_counts %>% dplyr::filter(expected_read, !is.na(CCLE_name)) %>%
     dplyr::select(!any_of(c('members'))) %>%
-    merge(cell_set_meta, by="cell_set", all.x=T) %>%
-    dplyr::mutate(members= ifelse(is.na(members), cell_set, members), # for custom cell sets
-                  expected_num_cl = as.character(members) %>% purrr::map(strsplit, ";") %>% 
+    dplyr::left_join(cell_set_meta, by="cell_set", relationship= 'many-to-one') %>%
+    dplyr::mutate(members= if_else(is.na(members), cell_set, members), # for custom cell sets
+                  expected_num_cl= as.character(members) %>% purrr::map(strsplit, ";") %>% 
                     purrr::map(`[[`, 1) %>% purrr::map(length) %>% as.numeric(),
                   count_type= ifelse(n > count_threshold, 'Detected', 'Low'),
                   count_type= ifelse(n==0, 'Missing', count_type)) %>%
     group_by(profile_id, pcr_plate, pcr_well, count_type, expected_num_cl) %>% 
-    dplyr::summarise(count= n()) %>% 
+    dplyr::summarise(count= dplyr::n()) %>% 
     dplyr::mutate(frac_type= count/expected_num_cl)
   
   cl_rec= recovery %>% ggplot() +
@@ -133,7 +155,91 @@ QC_images = function(sample_meta, raw_counts, annotated_counts, normalized_count
   
   contams %>% write.csv(file= paste(out, 'contams.csv', sep='/'), row.names=F)
   rm(contams)
-  #
+  
+  # Work in progress - Updating contaminant output with new filtered counts
+  run_below= F
+  if(run_below) {
+    # Determine which seq cols are present.
+    # sample_meta sequencing columns
+    sm_seq_cols= c('flowcell_name', 'flowcell_lane', 'IndexBarcode1', 'IndexBarcode2')
+    # raw_counts sequencing columns
+    rc_seq_cols= c('flowcell_name', 'flowcell_lane', 'index_1', 'index_2')
+    
+    mapped_reads= annotated_counts %>% 
+      dplyr::distinct(pick(any_of(c(sm_seq_cols, 'forward_read_cl_barcode', 'expected')))) %>%
+      dplyr::mutate(mapped=T)
+    
+    meta_joining_vector= list()
+    for(item in seq_cols) {
+      if(item=='IndexBarcode1') {
+        meta_joining_vector[['index_1']]= item
+      } else if(item=='IndexBarcode2') {
+        meta_joining_vector[['index_2']]= item
+      } else {
+        meta_joining_vector[[item]]= item
+      }
+    }
+    meta_joining_vector= unlist(meta_joining_vector)
+    
+    # unique combos of seq_cols
+    unique_seq_col_vals= sample_meta %>% dplyr::distinct(pick(any_of(sm_seq_cols)))
+    
+    # get unmapped reads
+    unmapped_read= raw_counts %>% 
+      dplyr::semi_join(unique_seq_col_vals, by= meta_joining_vector) %>%
+      dplyr::mutate(mapped= ifelse(forward_read_cl_barcode %in% c(cell_line_meta$Sequence, CB_meta$Sequence), T, F))
+    
+    dplyr::filter(index_1 %in% sample_meta$IndexBarcode1, index_2 %in% sample_meta$IndexBarcode2) %>%
+      dplyr::left_join(mapped_reads, by= c('index_1', 'index_2', 'forward_read_cl_barcode')) %>%
+      tidyr::replace_na(list(mapped= F)) %>% dplyr::filter(mapped== F) %>% dplyr::select(-mapped)
+    
+    # map of index barcodes to pcr_plate location
+    pcr_plate_map= sample_meta %>%
+      dplyr::distinct(pick(any_of(c('IndexBarcode1', 'IndexBarcode2', 'pcr_plate', 'pcr_well', 'cell_set')))) %>%
+      dplyr::group_by(pcr_plate) %>% dplyr::mutate(num_wells_in_plate= dplyr::n()) %>% dplyr::ungroup() %>%
+      dplyr::group_by(cell_set) %>% dplyr::mutate(num_wells_in_set= dplyr::n()) %>% dplyr::ungroup()
+    
+    # total counts per well - used to calculate fractions
+    counts_per_well= raw_counts %>%
+      dplyr::filter(index_1 %in% sample_meta$IndexBarcode1, index_2 %in% sample_meta$IndexBarcode2) %>%
+      dplyr::group_by(index_1, index_2) %>% dplyr::summarise(well_total_n= sum(n)) %>% dplyr::ungroup()
+    
+    # mapped contaminates to bind
+    mapped_contams= annotated_counts %>% dplyr::filter(!expected_read) %>%
+      dplyr::mutate(barcode_name= ifelse(is.na(CCLE_name), Name, CCLE_name)) %>%
+      dplyr::select(index_1, index_2, forward_read_cl_barcode, barcode_name, n)
+    
+    # put everything together
+    contam_reads= unmapped_read %>% dplyr::bind_rows(mapped_contams) %>%
+      dplyr::left_join(counts_per_well, by= c('index_1', 'index_2')) %>%
+      dplyr::left_join(pcr_plate_map, by= join_by('index_1'=='IndexBarcode1', 'index_2'=='IndexBarcode2')) %>%
+      # filter out barcodes that only appear in one well
+      dplyr::group_by(forward_read_cl_barcode) %>% dplyr::filter(dplyr::n() >1) %>% dplyr::ungroup() %>%
+      # number of wells in a pcr plate a barcode is detected in
+      dplyr::group_by(forward_read_cl_barcode, pcr_plate) %>%
+      dplyr::mutate(num_wells_detected_plate= n()) %>% dplyr::ungroup() %>%
+      # number of wells in a cell set a barcode is detected in
+      dplyr::group_by(forward_read_cl_barcode, cell_set) %>%
+      dplyr::mutate(num_wells_detected_set= n()) %>% dplyr::ungroup() %>%
+      # determine if contamination is project, plate, or set
+      dplyr::group_by(forward_read_cl_barcode) %>%
+      dplyr::mutate(num_wells_detected= dplyr::n(),
+                    project_code= unique(sample_meta$project_code),
+                    fraction= n/well_total_n,
+                    type1= ifelse(sum(num_wells_detected== nrow(pcr_plate_map))>1, 'project_contam', NA),
+                    type2= ifelse(sum(num_wells_detected== num_wells_detected_plate & 
+                                        num_wells_detected_plate == num_wells_in_plate)>1, 'plate_contam', NA),
+                    type3= ifelse(sum(num_wells_detected == num_wells_detected_set &
+                                        num_wells_detected_set== num_wells_in_set)>1, 'set_contam', NA)) %>%
+      dplyr::ungroup() %>%
+      tidyr::unite(scope, all_of(c('type1', 'type2', 'type3')), sep=',', remove = T, na.rm = T) %>%
+      dplyr::group_by(project_code, forward_read_cl_barcode, barcode_name, scope, num_wells_detected) %>%
+      dplyr::summarise(min_n= min(n), med_n= median(n), max_n= max(n),
+                       min_fraction= min(fraction), med_fraction= median(fraction), max_fraction=max(fraction)) %>%
+      dplyr::arrange(desc(max_fraction))
+    # GCCTATTAATCATTACTACTAATC
+    contam_reads %>% write.csv(paste0(folder_path, 'contam_reads.csv'), row.names=F)
+  }
   
   ## Cumulative counts by lines in negcons ----
   print("generating cummulative image")

--- a/R/QC_images.R
+++ b/R/QC_images.R
@@ -56,6 +56,11 @@ get_index_summary= function(df, index_col, valid_indices) {
 QC_images = function(sample_meta, raw_counts, annotated_counts, normalized_counts= NA,
                      CB_meta, cell_set_meta, out = NA, sig_cols, count_col_name= 'normalized_n',
                      control_type, count_threshold= 40, reverse_index2= FALSE) {
+  require(tidyverse)
+  require(magrittr)
+  require(reshape2)
+  require(scales)
+  
   if(is.na(out)) {
     out = getwd()
   }
@@ -65,7 +70,7 @@ QC_images = function(sample_meta, raw_counts, annotated_counts, normalized_count
   # Reverse index 2 barcodes
   if(reverse_index2) {
     print("Reverse-complementing index 2 barcode.")
-    sample_meta$IndexBarcode2= chartr("ATGC", "TACG", stringi::stri_reverse(sample_meta$IndexBarcode2))
+    sample_meta$index_2= chartr("ATGC", "TACG", stringi::stri_reverse(sample_meta$index_2))
   }
   
   # Detect control barcodes

--- a/R/QC_images.R
+++ b/R/QC_images.R
@@ -134,8 +134,7 @@ QC_images = function(sample_meta, raw_counts, annotated_counts, normalized_count
                     purrr::map(`[[`, 1) %>% purrr::map(length) %>% as.numeric(),
                   count_type= ifelse(n > count_threshold, 'Detected', 'Low'),
                   count_type= ifelse(n==0, 'Missing', count_type)) %>%
-    group_by(profile_id, pcr_plate, pcr_well, count_type, expected_num_cl) %>% 
-    dplyr::summarise(count= dplyr::n()) %>% 
+    dplyr::count(profile_id, pcr_plate, pcr_well, count_type, expected_num_cl, name= 'count') %>%
     dplyr::mutate(frac_type= count/expected_num_cl)
   
   cl_rec= recovery %>% ggplot() +
@@ -410,8 +409,7 @@ QC_images = function(sample_meta, raw_counts, annotated_counts, normalized_count
         filter(!is.na(CCLE_name),
                (!trt_type %in% c("empty", "", "CB_only")) & !is.na(trt_type)) %>% 
         mutate(plt_id= paste(sig_id, bio_rep, sep=':')) %>% 
-        reshape2::dcast(CCLE_name~plt_id, value.var="mean_normalized_n") %>% 
-        column_to_rownames("CCLE_name") %>% 
+        reshape2::acast(CCLE_name~plt_id, value.var="mean_normalized_n") %>% 
         cor(use="pairwise.complete.obs")
       
       bio_corr_hm= bio_corr %>% melt() %>% ggplot() +

--- a/R/QC_images.R
+++ b/R/QC_images.R
@@ -80,21 +80,21 @@ QC_images = function(sample_meta, raw_counts, annotated_counts, normalized_count
   print("Generating index counts tables")
   # Check that "IndexBarcode1" and "index_1" columns are present.
   # If so, calculate index summary and write out.
-  if('IndexBarcode1' %in% colnames(sample_meta) & 'index_1' %in% colnames(raw_counts)) {
-    expected_index1= unique(sample_meta$IndexBarcode1)
+  if('index_1' %in% colnames(sample_meta) & 'index_1' %in% colnames(raw_counts)) {
+    expected_index1= unique(sample_meta$index_1)
     index1_counts= get_index_summary(raw_counts, 'index_1', expected_index1)
     index1_counts %>% write.csv(file= paste(out, 'index1_counts.csv', sep='/'), row.names=F)
   } else {
-    print('Columns IndexBarcode1 and/or index_1 are not detected. Skipping index 1 summaries ...')
+    print('Column "index_1" not detected. Skipping index 1 summaries ...')
   }
   
   # Do the same for index 2.
-  if('IndexBarcode2' %in% colnames(sample_meta) & 'index_2' %in% colnames(raw_counts)) {
-    expected_index2= unique(sample_meta$IndexBarcode2)
+  if('index_2' %in% colnames(sample_meta) & 'index_2' %in% colnames(raw_counts)) {
+    expected_index2= unique(sample_meta$index_2)
     index2_counts= get_index_summary(raw_counts, 'index_2', expected_index2)
     index2_counts %>% write.csv(file= paste(out, 'index2_counts.csv', sep='/'), row.names=F)
   } else {
-    print('Columns IndexBarcode2 and/or index_2 are not detected. Skipping index 2 summaries ...')
+    print('Column "index_2" not detected. Skipping index 2 summaries ...')
   }
   
   ## Total counts ----

--- a/scripts/collate_fastq_reads.R
+++ b/scripts/collate_fastq_reads.R
@@ -11,7 +11,7 @@ parser$add_argument("-q", "--quietly", action="store_false", dest="verbose", hel
 parser$add_argument("-c", "--uncollapsed_raw_counts", default="raw_counts_uncollapsed.csv",
                     help="path to file containing uncollapsed raw counts file")
 parser$add_argument("--sample_meta", default="sample_meta.csv", help = "Sample metadata")
-parser$add_argument("--sequencing_index_cols", default= "IndexBarcode1,IndexBarcode2", 
+parser$add_argument("--sequencing_index_cols", default= "index_1,index_2", 
                     help = "Sequencing columns in the sample meta")
 parser$add_argument("-o", "--out", default=getwd(), help = "Output path. Default is working directory")
 
@@ -31,7 +31,7 @@ if(file.exists(expected_file_path)) {
   uncollapsed_raw_counts= data.table::fread(expected_file_path, header= T, sep= ',', data.table= F)
   sequencing_index_cols= unlist(strsplit(args$sequencing_index_cols, ","))
   
-  # QC: Check if sequencing_index_cols is composed of sample meta column names
+  # Validation: Check if sequencing_index_cols is composed of sample meta column names
   if (!all(sequencing_index_cols %in% colnames(sample_meta))) {
     stop(paste("Colnames not found in sample_meta, check metadata or --sequencing_index_cols argument:", 
                args$sequencing_index_cols))
@@ -40,7 +40,7 @@ if(file.exists(expected_file_path)) {
   print("Collating fastq reads")
   raw_counts= collate_fastq_reads(uncollapsed_raw_counts, sample_meta, sequencing_index_cols)
   
-  # QC: Basic file size check
+  # Validation: Basic file size check
   if(nrow(raw_counts) == 0) {
     stop('ERROR: Empty file generated. No rows in raw_counts output.')
   } 

--- a/scripts/collate_fastq_reads.R
+++ b/scripts/collate_fastq_reads.R
@@ -11,7 +11,8 @@ parser$add_argument("-q", "--quietly", action="store_false", dest="verbose", hel
 parser$add_argument("-c", "--uncollapsed_raw_counts", default="raw_counts_uncollapsed.csv",
                     help="path to file containing uncollapsed raw counts file")
 parser$add_argument("--sample_meta", default="sample_meta.csv", help = "Sample metadata")
-parser$add_argument("--seq_cols", default= "IndexBarcode1,IndexBarcode2", help = "Sequencing columns in the sample meta")
+parser$add_argument("--sequencing_index_cols", default= "IndexBarcode1,IndexBarcode2", 
+                    help = "Sequencing columns in the sample meta")
 parser$add_argument("-o", "--out", default=getwd(), help = "Output path. Default is working directory")
 
 # get command line options, if help option encountered print help and exit
@@ -28,15 +29,16 @@ expected_file_path <- paste(args$out, "raw_counts_uncollapsed.csv", sep='/')
 if(file.exists(expected_file_path)) {
   sample_meta= data.table::fread(args$sample_meta, header= T, sep= ',', data.table= F)
   uncollapsed_raw_counts= data.table::fread(expected_file_path, header= T, sep= ',', data.table= F)
-  seq_cols= unlist(strsplit(args$seq_cols, ","))
+  sequencing_index_cols= unlist(strsplit(args$sequencing_index_cols, ","))
   
-  # QC: Check if seq_cols is composed of sample meta column names
-  if (!all(seq_cols %in% colnames(sample_meta))) {
-    stop(paste("Colnames not found in sample_meta, check metadata or --seq_cols argument:", args$seq_cols))
+  # QC: Check if sequencing_index_cols is composed of sample meta column names
+  if (!all(sequencing_index_cols %in% colnames(sample_meta))) {
+    stop(paste("Colnames not found in sample_meta, check metadata or --sequencing_index_cols argument:", 
+               args$sequencing_index_cols))
   }
   
   print("Collating fastq reads")
-  raw_counts= collate_fastq_reads(uncollapsed_raw_counts, sample_meta, seq_cols)
+  raw_counts= collate_fastq_reads(uncollapsed_raw_counts, sample_meta, sequencing_index_cols)
   
   # QC: Basic file size check
   if(nrow(raw_counts) == 0) {

--- a/scripts/collate_fastq_reads.R
+++ b/scripts/collate_fastq_reads.R
@@ -3,39 +3,47 @@ library(magrittr)
 library(tidyverse)
 source("./src/collate_fastq_reads.R")
 
+# Parser ----
 parser <- ArgumentParser()
 # specify our desired options 
-parser$add_argument("-v", "--verbose", action="store_true", default=TRUE,
-                    help="Print extra output [default]")
-parser$add_argument("-q", "--quietly", action="store_false", 
-                    dest="verbose", help="Print little output")
+parser$add_argument("-v", "--verbose", action="store_true", default=TRUE, help="Print extra output [default]")
+parser$add_argument("-q", "--quietly", action="store_false", dest="verbose", help="Print little output")
 parser$add_argument("-c", "--uncollapsed_raw_counts", default="raw_counts_uncollapsed.csv",
                     help="path to file containing uncollapsed raw counts file")
 parser$add_argument("--sample_meta", default="sample_meta.csv", help = "Sample metadata")
+parser$add_argument("--seq_cols", default= "IndexBarcode1,IndexBarcode2", help = "Sequencing columns in the sample meta")
 parser$add_argument("-o", "--out", default=getwd(), help = "Output path. Default is working directory")
 
 # get command line options, if help option encountered print help and exit
 args <- parser$parse_args()
 
-#Save arguments
-if (args$out == ""){
+# set output to working directory if none is specified
+if (args$out == "") {
   args$out = args$wkdir
 }
 
-#build trigger
+# Run collate_fastq_reads if uncollapsed file exists ----
 expected_file_path <- paste(args$out, "raw_counts_uncollapsed.csv", sep='/')
 
-if (file.exists(expected_file_path)) {
-  sample_meta = read.csv(args$sample_meta)
-  uncollapsed_raw_counts = read.csv(expected_file_path)
-  print("Collating fastq reads")
-  raw_counts <- collate_fastq_reads(sample_meta, uncollapsed_raw_counts) 
+if(file.exists(expected_file_path)) {
+  sample_meta= data.table::fread(args$sample_meta, header= T, sep= ',', data.table= F)
+  uncollapsed_raw_counts= data.table::fread(expected_file_path, header= T, sep= ',', data.table= F)
+  seq_cols= unlist(strsplit(args$seq_cols, ","))
   
-  rc_out_file = paste(
-    args$out,
-    'raw_counts.csv',
-    sep='/'
-  )
+  # QC: Check if seq_cols is composed of sample meta column names
+  if (!all(seq_cols %in% colnames(sample_meta))) {
+    stop(paste("Colnames not found in sample_meta, check metadata or --seq_cols argument:", args$seq_cols))
+  }
+  
+  print("Collating fastq reads")
+  raw_counts= collate_fastq_reads(uncollapsed_raw_counts, sample_meta, seq_cols)
+  
+  # QC: Basic file size check
+  if(nrow(raw_counts) == 0) {
+    stop('ERROR: Empty file generated. No rows in raw_counts output.')
+  } 
+  
+  rc_out_file = paste(args$out, 'raw_counts.csv', sep='/')
   print(paste("Writing to file: ", rc_out_file))
   write.csv(raw_counts, rc_out_file, row.names=F, quote=F)
 } else {

--- a/scripts/filter_counts.R
+++ b/scripts/filter_counts.R
@@ -39,7 +39,8 @@ parser$add_argument("--cell_line_meta", default="cell_line_meta.csv", help = "Ce
 parser$add_argument("--cell_set_meta", default="cell_set_meta.csv", help = "Cell set metadata")
 parser$add_argument("--assay_pool_meta", default="assay_pool_meta.txt", help = "Assay pool metadata")
 parser$add_argument("--CB_meta", default="../metadata/CB_meta.csv", help = "Control Barcode metadata")
-parser$add_argument("--seq_cols", default= "IndexBarcode1,IndexBarcode2", help = "Sequencing columns in the sample meta")
+parser$add_argument("--sequencing_index_cols", default= "IndexBarcode1,IndexBarcode2", 
+                    help = "Sequencing columns in the sample meta")
 parser$add_argument("--id_cols", default="cell_set,treatment,dose,dose_unit,day,bio_rep,tech_rep",
                     help = "Columns used to generate profile ids, comma-separated colnames from --sample_meta")
 parser$add_argument("--count_threshold", default= 40, help = "Low counts threshold")
@@ -68,9 +69,10 @@ raw_counts= data.table::fread(args$raw_counts, header= T, sep= ',', data.table= 
 
 # Convert strings to vectors ----
 # Also check that column names are present in the sample meta.
-seq_cols= unlist(strsplit(args$seq_cols, ","))
-if (!all(seq_cols %in% colnames(sample_meta))){
-  stop(paste("All seq columns not found in sample_meta, check metadata or --seq_cols argument:", args$seq_cols))
+sequencing_index_cols= unlist(strsplit(args$sequencing_index_cols, ","))
+if (!all(sequencing_index_cols %in% colnames(sequencing_index_cols))){
+  stop(paste("All seq columns not found in sample_meta, check metadata or --sequencing_index_cols argument:", 
+             args$sequencing_index_cols))
 }
 
 id_cols= unlist(strsplit(args$id_cols, ","))
@@ -97,8 +99,8 @@ cell_line_meta %<>%
 
 # Remove flowcell_name and lane columns from sample_meta because
 # there is a profile_id duplicate when there are more than 1 seq runs
-sample_meta %<>% select(-flowcell_name, -flowcell_lane) %>%
-  distinct()
+#sample_meta %<>% select(-flowcell_name, -flowcell_lane) %>%
+ # distinct(). # This needs to be removed for sequencing_index_cols to work! - YL
 
 # Run filter_raw_reads -----
 print("creating filtered count file")
@@ -108,7 +110,7 @@ filtered_counts = filter_raw_reads(
   cell_line_meta,
   cell_set_meta,
   CB_meta,
-  seq_cols= seq_cols,
+  sequencing_index_cols= sequencing_index_cols,
   id_cols= id_cols,
   count_threshold= count_threshold,
   reverse_index2= args$reverse_index2

--- a/scripts/filter_counts.R
+++ b/scripts/filter_counts.R
@@ -39,7 +39,7 @@ parser$add_argument("--cell_line_meta", default="cell_line_meta.csv", help = "Ce
 parser$add_argument("--cell_set_meta", default="cell_set_meta.csv", help = "Cell set metadata")
 parser$add_argument("--assay_pool_meta", default="assay_pool_meta.txt", help = "Assay pool metadata")
 parser$add_argument("--CB_meta", default="../metadata/CB_meta.csv", help = "Control Barcode metadata")
-parser$add_argument("--sequencing_index_cols", default= "IndexBarcode1,IndexBarcode2", 
+parser$add_argument("--sequencing_index_cols", default= "index_1,index_2", 
                     help = "Sequencing columns in the sample meta")
 parser$add_argument("--id_cols", default="cell_set,treatment,dose,dose_unit,day,bio_rep,tech_rep",
                     help = "Columns used to generate profile ids, comma-separated colnames from --sample_meta")
@@ -132,10 +132,16 @@ if (args$pool_id) {
           by.y=c("ccle_name", "davepool_id", "depmap_id"), all.x=T)
 }
 
-# QC: Basic file size check ----
+# Validation: Basic file size check ----
 if(sum(filtered_counts$filtered_counts$n) == 0) {
-  stop('ERROR: All entries in filtered counts are missing')
+  stop('All entries in filtered counts are missing!')
 }
+
+cl_entries= filtered_counts %>% dplyr::filter(!is.na(CCLE_name))
+if(sum(cl_entries$n) == 0) {
+  stop('All cell line counts are zero!')
+}
+
 
 # Write out module outputs ----
 qc_table = filtered_counts$qc_table

--- a/scripts/filter_counts.R
+++ b/scripts/filter_counts.R
@@ -137,7 +137,7 @@ if(sum(filtered_counts$filtered_counts$n) == 0) {
   stop('All entries in filtered counts are missing!')
 }
 
-cl_entries= filtered_counts %>% dplyr::filter(!is.na(CCLE_name))
+cl_entries= filtered_counts$filtered_counts %>% dplyr::filter(!is.na(CCLE_name))
 if(sum(cl_entries$n) == 0) {
   stop('All cell line counts are zero!')
 }

--- a/scripts/filter_counts.R
+++ b/scripts/filter_counts.R
@@ -100,7 +100,7 @@ cell_line_meta %<>%
 # Remove flowcell_name and lane columns from sample_meta because
 # there is a profile_id duplicate when there are more than 1 seq runs
 #sample_meta %<>% select(-flowcell_name, -flowcell_lane) %>%
- # distinct(). # This needs to be removed for sequencing_index_cols to work! - YL
+ # distinct() # This needs to be removed for sequencing_index_cols to work! - YL
 
 # Run filter_raw_reads -----
 print("creating filtered count file")

--- a/scripts/filter_counts.R
+++ b/scripts/filter_counts.R
@@ -70,8 +70,8 @@ raw_counts= data.table::fread(args$raw_counts, header= T, sep= ',', data.table= 
 # Convert strings to vectors ----
 # Also check that column names are present in the sample meta.
 sequencing_index_cols= unlist(strsplit(args$sequencing_index_cols, ","))
-if (!all(sequencing_index_cols %in% colnames(sequencing_index_cols))){
-  stop(paste("All seq columns not found in sample_meta, check metadata or --sequencing_index_cols argument:", 
+if (!all(sequencing_index_cols %in% colnames(sample_meta))){
+  stop(paste("All seq columns not found in sample_meta, check metadata or --sequencing_index_cols argument:",
              args$sequencing_index_cols))
 }
 

--- a/scripts/filteredCounts_QC.R
+++ b/scripts/filteredCounts_QC.R
@@ -15,14 +15,13 @@ suppressPackageStartupMessages(library(prismSeqR))
 suppressPackageStartupMessages(library(scales)) # for out of bound handling in plots
 suppressPackageStartupMessages(library(ggpmisc)) # with ggplot to add fit line and labels
 
+# Parser ----
 parser <- ArgumentParser()
 # specify our desired options 
-parser$add_argument("-v", "--verbose", action="store_true", default=TRUE,
-                    help="Print extra output [default]")
-parser$add_argument("-q", "--quietly", action="store_false", 
-                    dest="verbose", help="Print little output")
+parser$add_argument("-v", "--verbose", action="store_true", default=TRUE, help="Print extra output [default]")
+parser$add_argument("-q", "--quietly", action="store_false", dest="verbose", help="Print little output")
 parser$add_argument("--wkdir", default=getwd(), help="Working directory")
-parser$add_argument("-s", "--sample_meta", default="sample_meta.csv", help = "Sample metadata")
+parser$add_argument("-s", "--sample_meta", default="sample_meta.csv", help= "Sample metadata")
 parser$add_argument("--raw_counts", default= "raw_counts.csv", help="path to file containing raw counts")
 parser$add_argument("--annotated_counts", default="annotated_counts.csv",
                     help="path to file containing annotated counts")
@@ -40,7 +39,8 @@ parser$add_argument("--count_col_name", default="normalized_n",
 parser$add_argument("--count_threshold", default=40, 
                     help = "Low counts threshold")
 parser$add_argument("--reverse_index2", default=FALSE, help = "Reverse index 2")
-parser$add_argument("--control_type", default = "negcon", help = "how negative control wells are distinguished in the trt_type column")
+parser$add_argument("--control_type", default = "negcon",
+                    help = "how negative control wells are distinguished in the trt_type column")
 # parser$add_argument("--db_flag", action="store_true", default=FALSE, help = "Use CellDB to locate cell set information")
 
 # get command line options, if help option encountered print help and exit
@@ -50,11 +50,12 @@ if (args$out == ""){
   args$out = args$wkdir
 }
 
-sample_meta = read.csv(args$sample_meta)
-raw_counts = read.csv(args$raw_counts)
-annotated_counts= read.csv(args$annotated_counts)
+# Read in files and pull out parameters ----
+sample_meta= data.table::fread(args$sample_meta, header= T, sep= ',', data.table= F)
+raw_counts= data.table::fread(args$raw_counts, header= T, sep= ',', data.table= F)
+annotated_counts= data.table::fread(args$annotated_counts, header= T, sep= ',', data.table= F)
 if(file.exists(args$normalized_counts)) {
-  normalized_counts= read.csv(args$normalized_counts)
+  normalized_counts= data.table::fread(args$normalized_counts, header= T, sep= ',', data.table= F)
 } else {
   normalized_counts= NA
 }

--- a/scripts/src/collate_fastq_reads.R
+++ b/scripts/src/collate_fastq_reads.R
@@ -11,24 +11,29 @@
 #'                 This defaults onto the following columns: "IndexBarcode1", "IndexBarcode2"
 #' @returns Returns a dataframe with the following columns - "index_1", "index_2", and "n"
 #' @import tidyverse
-collate_fastq_reads= function(uncollapsed_raw_counts, sample_meta, seq_cols) {
+collate_fastq_reads= function(uncollapsed_raw_counts, sample_meta, seq_cols= c('IndexBarcode1', 'IndexBarcode2')) {
   require(tidyverse)
   
+  # Change flowcell_lane to single lane in uncollapsed_raw_counts ----
+  # prevents name collision in future joins with sample meta
+  if(!'single_lane' %in% colnames(uncollapsed_raw_counts)) {
+    uncollapsed_raw_counts= dplyr::rename(uncollapsed_raw_counts, single_lane= flowcell_lane)
+  }
+  
   # Determine which flowcell names + lanes are expected ----
-  # Parse flowcell_lane by splitting on the chars , ; :
+  # flowcell_lane is a string, so parse it by splitting on the chars , ; :
   # Note: fread and read.csv keeps commas, read_csv DROPS commas
   meta_flowcells= sample_meta %>% dplyr::distinct(flowcell_name, flowcell_lane) %>%
-    dplyr::mutate(flowcell_lane= base::strsplit(flowcell_lane, split='[,;:]', fixed=F)) %>%
-    tidyr::unnest(cols= flowcell_lane) %>%
-    dplyr::mutate(flowcell_lane= as.numeric(flowcell_lane))
+    dplyr::mutate(single_lane= base::strsplit(flowcell_lane, split='[,;:]', fixed=F)) %>%
+    tidyr::unnest(cols= single_lane) %>%
+    dplyr::mutate(single_lane= as.numeric(single_lane))
   
   print(paste0('Identified ', nrow(meta_flowcells), ' unique flowcell + lane combos in the sample meta ...'))
   print(meta_flowcells)
   
   # QC: Check that all expected flowcell name + lanes are detected ----
-  missing_flowcells= uncollapsed_raw_counts %>% dplyr::distinct(flowcell_name, flowcell_lane) %>% dplyr::mutate(present=T) %>%
-    dplyr::right_join(meta_flowcells, by=c('flowcell_name', 'flowcell_lane')) %>%
-    dplyr::filter(is.na(present))
+  missing_flowcells= uncollapsed_raw_counts %>% dplyr::distinct(flowcell_name, single_lane) %>%
+    dplyr::anti_join(meta_flowcells, by= c('flowcell_name', 'single_lane'))
   if(nrow(missing_flowcells)!= 0) {
     print('The following flowcells/lanes specified in the sample meta were not detected in the fastq reads.')
     print(missing_flowcells)
@@ -66,7 +71,7 @@ collate_fastq_reads= function(uncollapsed_raw_counts, sample_meta, seq_cols) {
   # Create raw counts by summing over appropriate seq_cols ----
   # use an inner join to collect reads with valid flowcell name/lane combinations, then sum using index pairs
   raw_counts= uncollapsed_raw_counts %>% 
-    dplyr::inner_join(meta_flowcells, by= c('flowcell_name', 'flowcell_lane'), relationship= 'many-to-one') %>%
+    dplyr::inner_join(meta_flowcells, by= c('flowcell_name', 'single_lane'), relationship= 'many-to-one') %>%
     dplyr::group_by(pick(all_of(c(converted_seq_cols, 'forward_read_cl_barcode')))) %>% 
     dplyr::summarize(n= sum(n)) %>% dplyr::ungroup()
   

--- a/scripts/src/collate_fastq_reads.R
+++ b/scripts/src/collate_fastq_reads.R
@@ -1,97 +1,137 @@
+#' validate_columns_exist
+#' 
+#' This function checks that a list of columns are present in a dataframe.
+#' 
+#' @param selected_columns A vector of strings each representing a column name
+#' @param df A dataframe to check against
+#' @return Boolean
+validate_columns_exist= function(selected_columns, df) {
+  # Check that all of selected_columns are in df
+  if(any(!selected_columns %in% colnames(df))) {
+    return(FALSE)
+  } else {
+    return(TRUE)
+  }
+}
+  
+#' validate_columns_entries
+#' 
+#' This function checks that for a list of columns, all entries are filled in.
+#' It checks all column entries against a list of potential empty values.
+#' 
+#' @param selected_columns A vector of strings each representing a column name
+#' @param df A dataframe to check against
+#' @param empty_values Optional vector of values that equate to empty. Defaults to NA, "NA", "", and " ".
+#' @return Boolean
+validate_columns_entries= function(selected_columns, df, empty_values= c(NA, 'NA', '', ' ')) {
+  # Check for rows in selected_columns that equate to predefined empty values.
+  missing_rows= df %>% dplyr::filter(if_any(all_of(selected_columns), ~ . %in% empty_values))
+  if(nrow(missing_rows) > 0) {
+    print('The following rows in the sample meta are not filled out for the sequencing index columns.')
+    print(missing_rows) # show the empty rows
+    return(FALSE)
+  } else {
+    return(TRUE)
+  }
+}
+
+#' validate_unique_samples
+#' 
+#' This function checks that a list of columns uniquely identifies all entries of a dataframe.
+#' 
+#' @param selected_columns A vector of strings each representing a column name
+#' @param df A dataframe to check against
+#' @return Boolean
+validate_unique_samples= function(selected_columns, df) {
+  unique_column_values= df %>% dplyr::distinct(pick(all_of(selected_columns)))
+  if(nrow(unique_column_values) != nrow(df)) {
+    return(FALSE)
+  } else {
+    return(TRUE)
+  }
+}
+
 #' collate_fastq_reads
 #' 
 #' This function takes in the fastq reads (uncollapsed_raw_counts) and
 #' filters for reads coming from flowcells specificed in the sample meta.
-#' The function then sums up the reads the flowcells using the index pairs.
+#' The function then sums up the reads across specified sequencing index columns.
 #' 
 #' @param uncollapsed_raw_counts Data frame of reads from all the fastq files with the following columns - \cr
 #'                    "flowcell_name", "flowcell_lane", "index_1", "index_2", and "forward_read_cl_barcode", "n"
-#' @param sample_meta Sample metadata generate for the project  
+#' @param sample_meta Sample metadata generate for the project which may contain the following columns - 
+#'                    "flowcell_names", "flowcell_lanes", "index_1", "index_2". The sample meta must contain
+#'                    "flowcell_names" and "flowcell_lanes" for filtering.
 #' @param sequencing_index_cols Sequencing columns from the sample meta that the counts should be collapsed on. \cr
-#'                              This defaults onto the following columns: "IndexBarcode1", "IndexBarcode2"
+#'                              This defaults onto the following columns: "index_1", "index_2"
 #' @returns Returns a dataframe with columns specified by the sequencing_index_cols, "forward_read_cl_barcode", and "n".
 #' @import tidyverse
-collate_fastq_reads= function(uncollapsed_raw_counts, sample_meta, 
-                              sequencing_index_cols= c('IndexBarcode1', 'IndexBarcode2')) {
+collate_fastq_reads= function(uncollapsed_raw_counts, sample_meta, sequencing_index_cols= c('index_1', 'index_2')) {
   require(tidyverse)
   
-  # Change flowcell_lane to single lane in uncollapsed_raw_counts ----
-  # Uncollapsed raw counts's flowcell_lane is a single value, but 
-  # sample meta's flowcell_lane is a string of numbers to parse.
-  # These should be different columns in the event that you need to collapse over different groups of lanes.
-  if(!'single_lane' %in% colnames(uncollapsed_raw_counts)) {
-    uncollapsed_raw_counts= dplyr::rename(uncollapsed_raw_counts, single_lane= flowcell_lane)
+  # Validation: Check that flowcell_names and flowcell_lanes exist in the sample meta ----
+  if(!validate_columns_exist(c('flowcell_names', 'flowcell_lanes'), sample_meta)) {
+    stop('flowcell_names and/or flowcell_lanes is NOT present in the sample meta.')
+  }
+  
+  # Validation: Check that sequencing_index_cols exist in the sample meta ----
+  if(!validate_columns_exist(sequencing_index_cols, sample_meta)) {
+    stop('One or more sequencing_index_cols is NOT present in the sample meta.')
+  }
+  
+  # Validation: Check that sequencing_index_cols in the sample meta are filled out ----
+  # Check for rows in sequencing_index_cols that equate to empty - NA, "NA", "", " "
+  # Error out of the sequencing_index_cols are not filled out in the sample meta.
+  if(!validate_columns_entries(sequencing_index_cols, sample_meta)) {
+    stop('One or more sequencing_index_cols in the sample meta is not filled out.')
+  }
+  
+  # Validation: Check that sequencing_index_cols uniquely identify rows of sample meta ----
+  if(!validate_unique_samples(sequencing_index_cols, sample_meta)) {
+    print('There may be multiple entries in the sample meta that have the same combination of sequencing index columns.')
+    stop('The specified sequencing index columns do NOT uniquely identify every PCR well.')
   }
   
   # Determine which flowcell names + lanes are expected ----
-  # "flowcell_lane" is a string containing a group of lanes, to be parsed by splitting on the chars , ; :
-  # "single_lane" contains the individual lane as a number.
+  # "flowcell_names" and "flowcell_lanes" are strings that can contain more than one item.
+  # Columns can be parsed by splitting on the chars , ; :
+  # If there are multiple lane names and lane numbers, this uses the Cartesian product!
   # Note: fread and read.csv keeps commas, read_csv DROPS commas
-  meta_flowcells= sample_meta %>% dplyr::distinct(flowcell_name, flowcell_lane) %>%
-    dplyr::mutate(single_lane= base::strsplit(flowcell_lane, split='[,;:]', fixed=F)) %>% 
-    tidyr::unnest(cols= single_lane) %>%
-    dplyr::mutate(single_lane= as.numeric(single_lane))
+  meta_flowcells= sample_meta %>% dplyr::distinct(flowcell_names, flowcell_lanes) %>%
+    dplyr::mutate(flowcell_name= base::strsplit(flowcell_names, split='[,;:]', fixed=F),
+                  flowcell_lane= base::strsplit(flowcell_lanes, split='[,;:]', fixed=F)) %>% 
+    tidyr::unnest(cols= flowcell_name) %>% tidyr::unnest(cols= flowcell_lane) %>%
+    dplyr::mutate(flowcell_lane= as.numeric(flowcell_lane))
   
   # Print out expected flowcells from the sample meta.
   print(paste0('Identified ', nrow(meta_flowcells), ' unique flowcell + lane combos in the sample meta ...'))
   print(meta_flowcells)
   
-  # QC: Check that all expected flowcell name + lanes are detected ----
+  # Print warning if there are multiple flowcell names with multiple flowcell lanes.
+  multi_name_and_lanes= meta_flowcells %>% dplyr::filter(grepl(',:;', flowcell_names) & grepl(',:;', flowcell_names))
+  if(nrow(multi_name_and_lanes) > 0) {
+    print('WARNING: Detected sample(s) sequenced over multiple flowcells and flowcell lanes.')
+    print('The function assumes that the same lanes were used for both flowcells.')
+  }
+  
+  # Validation: Check that all expected flowcell name + lanes are detected ----
   # Check that all expected flowcell name + lanes are present in uncollapsed raw counts.
   missing_flowcells= meta_flowcells %>%
-    dplyr::anti_join(uncollapsed_raw_counts %>% dplyr::distinct(flowcell_name, single_lane),
-                     by= c('flowcell_name', 'single_lane'))
+    dplyr::anti_join(uncollapsed_raw_counts %>% dplyr::distinct(flowcell_name, flowcell_lane),
+                     by= c('flowcell_name', 'flowcell_lane'))
   if(nrow(missing_flowcells)!= 0) {
     print('The following flowcells/lanes specified in the sample meta were not detected in the fastq reads.')
     print(missing_flowcells)
     print('Check that the sample meta is correct or that all fastq files are in the correct directory.')
-    stop('ERROR: One or more flowcell specified in the sample meta was not detected.')
-  }
-  
-  # QC: Check that sequencing_index_cols are present in the sample meta ----
-  if(any(!sequencing_index_cols %in% colnames(sample_meta))) {
-    stop('ERROR: One or more sequencing_index_cols is not present in the sample meta.')
-  }
-  
-  # QC: Check that sequencing_index_cols in the sample meta are filled out ----
-  # Check for rows in sequencing_index_cols that equate to empty - NA, "NA", "", " "
-  # Error out of the sequencing_index_cols are not filled out in the sample meta.
-  missing_rows_sequencing_index_cols= sample_meta %>% 
-    dplyr::filter(if_any(all_of(sequencing_index_cols), ~ . %in% c(NA, 'NA', '', ' ')))
-  if(nrow(missing_rows_sequencing_index_cols) > 0) {
-    print('The following rows in the sample meta are not filled out for the sequencing index columns.')
-    print(missing_rows_sequencing_index_cols) # show the empty rows
-    stop('ERROR: One or more sequencing_index_cols in the sample meta is not filled out.')
-  }
-  
-  # QC: Check that sequencing_index_cols uniquely identify rows of sample meta ----
-  # Find the unique combinations of sequencing_index_cols and check that it matches the number of row in the sample meta.
-  unique_sequencing_index_vals= sample_meta %>% dplyr::distinct(pick(all_of(sequencing_index_cols)))
-  if(nrow(unique_sequencing_index_vals) != nrow(sample_meta)) {
-    print('There may be multiple entries in the sample meta that have the same combination of sequencing index columns.')
-    stop('ERROR: The specified sequencing index columns do NOT uniquely identify every PCR well.')
-  }
-  
-  # Convert sequencing_index_cols to equivalent names in uncollapsed file ----
-  # Some columns that represent the same things are called different names 
-  # between the sample meta and uncollapsed raw counts. The following code converts one name to the other. 
-  converted_sequencing_index_cols= c() 
-  for(item in sequencing_index_cols) {
-    if(item=='IndexBarcode1') {
-      converted_sequencing_index_cols= c(converted_sequencing_index_cols, 'index_1')
-    } else if(item=='IndexBarcode2') {
-      converted_sequencing_index_cols= c(converted_sequencing_index_cols, 'index_2')
-    } else {
-      converted_sequencing_index_cols= c(converted_sequencing_index_cols, item)
-    }
+    stop('One or more flowcell specified in the sample meta was not detected.')
   }
   
   # Create raw counts by summing over appropriate sequencing_index_cols ----
   # Use an inner join to collect reads with valid flowcell name/lane combinations, 
   # then sum reads across sequencing columns
   raw_counts= uncollapsed_raw_counts %>% 
-    dplyr::inner_join(meta_flowcells, by= c('flowcell_name', 'single_lane'), relationship= 'many-to-one') %>%
-    dplyr::group_by(pick(all_of(c(converted_sequencing_index_cols, 'forward_read_cl_barcode')))) %>% 
+    dplyr::inner_join(meta_flowcells, by= c('flowcell_name', 'flowcell_lane'), relationship= 'many-to-one') %>%
+    dplyr::group_by(pick(all_of(c(sequencing_index_cols, 'forward_read_cl_barcode')))) %>% 
     dplyr::summarize(n= sum(n)) %>% dplyr::ungroup()
   
   return(raw_counts)

--- a/scripts/src/collate_fastq_reads.R
+++ b/scripts/src/collate_fastq_reads.R
@@ -9,7 +9,7 @@
 #' @param sample_meta Sample metadata generate for the project  
 #' @param sequencing_index_cols Sequencing columns from the sample meta that the counts should be collapsed on. \cr
 #'                              This defaults onto the following columns: "IndexBarcode1", "IndexBarcode2"
-#' @returns Returns a dataframe with the following columns - "index_1", "index_2", and "n"
+#' @returns Returns a dataframe with columns specified by the sequencing_index_cols, "forward_read_cl_barcode", and "n".
 #' @import tidyverse
 collate_fastq_reads= function(uncollapsed_raw_counts, sample_meta, 
                               sequencing_index_cols= c('IndexBarcode1', 'IndexBarcode2')) {
@@ -25,10 +25,10 @@ collate_fastq_reads= function(uncollapsed_raw_counts, sample_meta,
   
   # Determine which flowcell names + lanes are expected ----
   # "flowcell_lane" is a string containing a group of lanes, to be parsed by splitting on the chars , ; :
-  # "single_lane" contains the individual lane
+  # "single_lane" contains the individual lane as a number.
   # Note: fread and read.csv keeps commas, read_csv DROPS commas
   meta_flowcells= sample_meta %>% dplyr::distinct(flowcell_name, flowcell_lane) %>%
-    dplyr::mutate(single_lane= base::strsplit(flowcell_lane, split='[,;:]', fixed=F)) %>%
+    dplyr::mutate(single_lane= base::strsplit(flowcell_lane, split='[,;:]', fixed=F)) %>% 
     tidyr::unnest(cols= single_lane) %>%
     dplyr::mutate(single_lane= as.numeric(single_lane))
   

--- a/scripts/src/collate_fastq_reads.R
+++ b/scripts/src/collate_fastq_reads.R
@@ -4,15 +4,17 @@
 #' filters for reads coming from flowcells specificed in the sample meta.
 #' The function then sums up the reads the flowcells using the index pairs.
 #' 
-#' @param sample_meta Sample metadata generate for the project
 #' @param uncollapsed_raw_counts Data frame of reads from all the fastq files with the following columns - \cr
-#'                    "flowcell_name", "flowcell_lane", "index_1", "index_2", and "n"
+#'                    "flowcell_name", "flowcell_lane", "index_1", "index_2", and "forward_read_cl_barcode", "n"
+#' @param sample_meta Sample metadata generate for the project  
+#' @param seq_cols Sequencing columns from the sample meta taht the counts should be collapsed on. \cr
+#'                 This defaults onto the following columns: "IndexBarcode1", "IndexBarcode2"
 #' @returns Returns a dataframe with the following columns - "index_1", "index_2", and "n"
 #' @import tidyverse
-collate_fastq_reads= function(sample_meta, uncollapsed_raw_counts) {
+collate_fastq_reads= function(uncollapsed_raw_counts, sample_meta, seq_cols) {
   require(tidyverse)
   
-  # Determine which flowcell names + lanes are expected
+  # Determine which flowcell names + lanes are expected ----
   # Parse flowcell_lane by splitting on the chars , ; :
   # Note: fread and read.csv keeps commas, read_csv DROPS commas
   meta_flowcells= sample_meta %>% dplyr::distinct(flowcell_name, flowcell_lane) %>%
@@ -23,7 +25,7 @@ collate_fastq_reads= function(sample_meta, uncollapsed_raw_counts) {
   print(paste0('Identified ', nrow(meta_flowcells), ' unique flowcell + lane combos in the sample meta ...'))
   print(meta_flowcells)
   
-  # check that expected flowcells are detected
+  # QC: Check that all expected flowcell name + lanes are detected ----
   missing_flowcells= uncollapsed_raw_counts %>% dplyr::distinct(flowcell_name, flowcell_lane) %>% dplyr::mutate(present=T) %>%
     dplyr::right_join(meta_flowcells, by=c('flowcell_name', 'flowcell_lane')) %>%
     dplyr::filter(is.na(present))
@@ -34,9 +36,38 @@ collate_fastq_reads= function(sample_meta, uncollapsed_raw_counts) {
     stop('ERROR: One or more flowcell specified in the sample meta was not detected.')
   }
   
+  # QC: Check that seq_cols are present in the sample meta ----
+  if(any(!seq_cols %in% colnames(sample_meta))) {
+    stop('ERROR: One or more seq_col is not present in the sample meta.')
+  }
+  
+  # QC: Check that seq_cols in the sample meta are filled out ----
+  # check for rows in seq_cols that equate to empty - NA, "NA", "", " "
+  missing_rows_seq_cols= sample_meta %>% dplyr::filter(if_any(all_of(seq_cols), ~ . %in% c(NA, 'NA', '', ' ')))
+  if(nrow(missing_rows_seq_cols) > 0) {
+    print('The following rows in the sample meta are not filled out for all of the sequencing columns.')
+    print(missing_rows_seq_cols)
+    stop('ERROR: One or more seq col in the sample meta is not filled out.')
+  }
+  
+  # Convert seq_cols to equivalent names in uncollapsed file ----
+  # column names in uncollapsed_raw_counts are not the same as those in the sample meta
+  converted_seq_cols= c() 
+  for(item in seq_cols) {
+    if(item=='IndexBarcode1') {
+      converted_seq_cols= c(converted_seq_cols, 'index_1')
+    } else if(item=='IndexBarcode2') {
+      converted_seq_cols= c(converted_seq_cols, 'index_2')
+    } else {
+      converted_seq_cols= c(converted_seq_cols, item)
+    }
+  }
+  
+  # Create raw counts by summing over appropriate seq_cols ----
   # use an inner join to collect reads with valid flowcell name/lane combinations, then sum using index pairs
-  raw_counts= uncollapsed_raw_counts %>% dplyr::inner_join(meta_flowcells, by=c('flowcell_name', 'flowcell_lane')) %>%
-    dplyr::group_by(index_1, index_2, forward_read_cl_barcode) %>% 
+  raw_counts= uncollapsed_raw_counts %>% 
+    dplyr::inner_join(meta_flowcells, by= c('flowcell_name', 'flowcell_lane'), relationship= 'many-to-one') %>%
+    dplyr::group_by(pick(all_of(c(converted_seq_cols, 'forward_read_cl_barcode')))) %>% 
     dplyr::summarize(n= sum(n)) %>% dplyr::ungroup()
   
   return(raw_counts)

--- a/scripts/src/collate_fastq_reads.R
+++ b/scripts/src/collate_fastq_reads.R
@@ -7,11 +7,12 @@
 #' @param uncollapsed_raw_counts Data frame of reads from all the fastq files with the following columns - \cr
 #'                    "flowcell_name", "flowcell_lane", "index_1", "index_2", and "forward_read_cl_barcode", "n"
 #' @param sample_meta Sample metadata generate for the project  
-#' @param seq_cols Sequencing columns from the sample meta taht the counts should be collapsed on. \cr
-#'                 This defaults onto the following columns: "IndexBarcode1", "IndexBarcode2"
+#' @param sequencing_index_cols Sequencing columns from the sample meta that the counts should be collapsed on. \cr
+#'                              This defaults onto the following columns: "IndexBarcode1", "IndexBarcode2"
 #' @returns Returns a dataframe with the following columns - "index_1", "index_2", and "n"
 #' @import tidyverse
-collate_fastq_reads= function(uncollapsed_raw_counts, sample_meta, seq_cols= c('IndexBarcode1', 'IndexBarcode2')) {
+collate_fastq_reads= function(uncollapsed_raw_counts, sample_meta, 
+                              sequencing_index_cols= c('IndexBarcode1', 'IndexBarcode2')) {
   require(tidyverse)
   
   # Change flowcell_lane to single lane in uncollapsed_raw_counts ----
@@ -47,49 +48,50 @@ collate_fastq_reads= function(uncollapsed_raw_counts, sample_meta, seq_cols= c('
     stop('ERROR: One or more flowcell specified in the sample meta was not detected.')
   }
   
-  # QC: Check that seq_cols are present in the sample meta ----
-  if(any(!seq_cols %in% colnames(sample_meta))) {
-    stop('ERROR: One or more seq_col is not present in the sample meta.')
+  # QC: Check that sequencing_index_cols are present in the sample meta ----
+  if(any(!sequencing_index_cols %in% colnames(sample_meta))) {
+    stop('ERROR: One or more sequencing_index_cols is not present in the sample meta.')
   }
   
-  # QC: Check that seq_cols in the sample meta are filled out ----
-  # Check for rows in seq_cols that equate to empty - NA, "NA", "", " "
-  # Error out of the seq_cols are not filled out in the sample meta.
-  missing_rows_seq_cols= sample_meta %>% dplyr::filter(if_any(all_of(seq_cols), ~ . %in% c(NA, 'NA', '', ' ')))
-  if(nrow(missing_rows_seq_cols) > 0) {
-    print('The following rows in the sample meta are not filled out for all of the sequencing columns.')
-    print(missing_rows_seq_cols) # show the empty rows
-    stop('ERROR: One or more seq col in the sample meta is not filled out.')
+  # QC: Check that sequencing_index_cols in the sample meta are filled out ----
+  # Check for rows in sequencing_index_cols that equate to empty - NA, "NA", "", " "
+  # Error out of the sequencing_index_cols are not filled out in the sample meta.
+  missing_rows_sequencing_index_cols= sample_meta %>% 
+    dplyr::filter(if_any(all_of(sequencing_index_cols), ~ . %in% c(NA, 'NA', '', ' ')))
+  if(nrow(missing_rows_sequencing_index_cols) > 0) {
+    print('The following rows in the sample meta are not filled out for the sequencing index columns.')
+    print(missing_rows_sequencing_index_cols) # show the empty rows
+    stop('ERROR: One or more sequencing_index_cols in the sample meta is not filled out.')
   }
   
-  # QC: Check that seq_cols uniquely identify rows of sample meta ----
-  # Find the unique combinations of seq_cols and check that it matches the number of row in the sample meta.
-  unique_seq_col_vals= sample_meta %>% dplyr::distinct(pick(all_of(seq_cols)))
-  if(nrow(unique_seq_col_vals) != nrow(sample_meta)) {
-    print('There may be multiple entries in the sample meta that have the same combination of sequencing columns.')
-    stop('ERROR: The specified sequencing columns do NOT uniquely identify every PCR well.')
+  # QC: Check that sequencing_index_cols uniquely identify rows of sample meta ----
+  # Find the unique combinations of sequencing_index_cols and check that it matches the number of row in the sample meta.
+  unique_sequencing_index_vals= sample_meta %>% dplyr::distinct(pick(all_of(sequencing_index_cols)))
+  if(nrow(unique_sequencing_index_vals) != nrow(sample_meta)) {
+    print('There may be multiple entries in the sample meta that have the same combination of sequencing index columns.')
+    stop('ERROR: The specified sequencing index columns do NOT uniquely identify every PCR well.')
   }
   
-  # Convert seq_cols to equivalent names in uncollapsed file ----
+  # Convert sequencing_index_cols to equivalent names in uncollapsed file ----
   # Some columns that represent the same things are called different names 
   # between the sample meta and uncollapsed raw counts. The following code converts one name to the other. 
-  converted_seq_cols= c() 
-  for(item in seq_cols) {
+  converted_sequencing_index_cols= c() 
+  for(item in sequencing_index_cols) {
     if(item=='IndexBarcode1') {
-      converted_seq_cols= c(converted_seq_cols, 'index_1')
+      converted_sequencing_index_cols= c(converted_sequencing_index_cols, 'index_1')
     } else if(item=='IndexBarcode2') {
-      converted_seq_cols= c(converted_seq_cols, 'index_2')
+      converted_sequencing_index_cols= c(converted_sequencing_index_cols, 'index_2')
     } else {
-      converted_seq_cols= c(converted_seq_cols, item)
+      converted_sequencing_index_cols= c(converted_sequencing_index_cols, item)
     }
   }
   
-  # Create raw counts by summing over appropriate seq_cols ----
+  # Create raw counts by summing over appropriate sequencing_index_cols ----
   # Use an inner join to collect reads with valid flowcell name/lane combinations, 
   # then sum reads across sequencing columns
   raw_counts= uncollapsed_raw_counts %>% 
     dplyr::inner_join(meta_flowcells, by= c('flowcell_name', 'single_lane'), relationship= 'many-to-one') %>%
-    dplyr::group_by(pick(all_of(c(converted_seq_cols, 'forward_read_cl_barcode')))) %>% 
+    dplyr::group_by(pick(all_of(c(converted_sequencing_index_cols, 'forward_read_cl_barcode')))) %>% 
     dplyr::summarize(n= sum(n)) %>% dplyr::ungroup()
   
   return(raw_counts)

--- a/scripts/src/filter_raw_reads.R
+++ b/scripts/src/filter_raw_reads.R
@@ -41,8 +41,8 @@ suppressPackageStartupMessages(library(sets))
 #'   \item qc_table: QC table of index_purity and cell_line_purity 
 #' }
 #' @export 
-filter_raw_reads = function(raw_counts, sample_meta, cell_line_meta, 
-                            cell_set_meta, CB_meta,
+filter_raw_reads = function(raw_counts, 
+                            sample_meta, cell_line_meta, cell_set_meta, CB_meta,
                             seq_cols= c('IndexBarcode1', 'IndexBarcode2'),
                             id_cols=c('cell_set','treatment','dose','dose_unit','day','bio_rep','tech_rep'),
                             reverse_index2= FALSE, count_threshold= 40) {

--- a/scripts/src/filter_raw_reads.R
+++ b/scripts/src/filter_raw_reads.R
@@ -152,7 +152,7 @@ filter_raw_reads = function(raw_counts,
   # or below a count threshold.
   print("Filtering reads ...")
   filtered_counts= annotated_counts %>% dplyr::filter(expected_read) %>%
-    dplyr::select(!any_of(c(sequencing_index_cols, 'index_1', 'index_2', 'forward_read_cl_barcode',
+    dplyr::select(!any_of(c('flowcell_name', 'flowcell_lane', 'index_1', 'index_2', 'forward_read_cl_barcode',
                             'LUA', 'expected_read'))) %>%
     dplyr::mutate(flag= ifelse(n==0, 'Missing', NA),
                   flag= ifelse(n!=0 & n < count_threshold, 'low counts', flag))

--- a/scripts/src/filter_raw_reads.R
+++ b/scripts/src/filter_raw_reads.R
@@ -152,8 +152,8 @@ filter_raw_reads = function(raw_counts,
   # or below a count threshold.
   print("Filtering reads ...")
   filtered_counts= annotated_counts %>% dplyr::filter(expected_read) %>%
-    dplyr::select(!any_of(c('flowcell_name', 'flowcell_lane', 'index_1', 'index_2', 'forward_read_cl_barcode',
-                            'LUA', 'expected_read'))) %>%
+    dplyr::select(!any_of(c('flowcell_name', 'flowcell_lane', 'index_1', 'index_2', 'IndexBarcode1', 'IndexBarcode2',
+                            'forward_read_cl_barcode', 'LUA', 'expected_read'))) %>%
     dplyr::mutate(flag= ifelse(n==0, 'Missing', NA),
                   flag= ifelse(n!=0 & n < count_threshold, 'low counts', flag))
   

--- a/scripts/src/filter_raw_reads.R
+++ b/scripts/src/filter_raw_reads.R
@@ -48,6 +48,7 @@ filter_raw_reads = function(raw_counts,
                             reverse_index2= FALSE, count_threshold= 40) {
   
   require(tidyverse)
+  require(magrittr)
   
   # Processing metadata and inputs ---- 
   # CB meta is in log10 and should be converted to log2.


### PR DESCRIPTION
Handle instances where index barcodes are shared.
- Added a parameter "sequencing_index_cols" to specify the sequencing related columns needed to uniquely identify every PCR wells.
- Changed the script and module for collate_fastq_reads to accommodate new parameter. 
- Changed the script and module for filtered_counts to accommodate new parameter.
- Changed read.csv to fread.
- Added some additional checks to collate_fastq_reads and filter_raw_reads.
- Added additional comments