### PR TITLE
Test new cell endpoint

### DIFF
--- a/scripts/EPS_QC.R
+++ b/scripts/EPS_QC.R
@@ -48,7 +48,7 @@ if (length(norm_count_files) == 1) {
 
 ## get negcon counts at day in QC table to pass to portal
 cell_counts_negcon <- norm_counts %>% 
-    dplyr::filter(!is.na(depmap_id)) %>%
+    dplyr::filter(is.na(cb_name)) %>%
     dplyr::filter(!(day %in% days_to_drop)) %>% 
     dplyr::filter(pert_type==control_type)
 

--- a/scripts/create_cellDB_metadata.R
+++ b/scripts/create_cellDB_metadata.R
@@ -113,7 +113,10 @@ if(all(cell_set_meta_long$cell_set %in% assay_pools_meta$davepool_id)) {
     select(cell_set, depmap_id = members)
 }
 
-
+# Join CB_meta with cell_line_meta
+if (nrow(CB_meta) > 0) {
+  CB_meta <- dplyr::left_join(CB_meta, cell_line_meta, by = "forward_read_barcode")
+}
 # Writing out cell_line_meta
 cell_line_out_file = paste(args$out, 'cell_line_meta.csv', sep='/')
 print(paste("writing cell_line_meta to: ", cell_line_out_file))

--- a/scripts/create_cellDB_metadata.R
+++ b/scripts/create_cellDB_metadata.R
@@ -54,15 +54,15 @@ if (args$api_key != ""){
 
 print("Using CellDB to locate cell information.")
 print(api_url)
-cell_sets_df <- get_cell_api_info(paste(api_url,"cell_sets", sep = "/"), api_key)
-cell_pools_df <- get_cell_api_info(paste(api_url,"assay_pools", sep = "/"), api_key)
-cell_lines_df <- get_cell_api_info(paste(api_url,"cell_lines", sep = "/"), api_key)
-assay_pools_df <- get_cell_api_info(paste(api_url,"cell_set_definition_files", sep = "/"), api_key)
+cell_sets_df <- get_cell_api_info(paste(api_url,"e_cell_sets", sep = "/"), api_key)
+cell_pools_df <- get_cell_api_info(paste(api_url,"e_assay_pools", sep = "/"), api_key)
+cell_lines_df <- get_cell_api_info(paste(api_url,"e_cell_lines", sep = "/"), api_key)
+assay_pools_df <- get_cell_api_info(paste(api_url,"e_cell_set_definition_files", sep = "/"), api_key)
 assay_pools_meta <- select(assay_pools_df, -cell_set_desc)
 
 #if custom cb_ladder is not provided, pull from CellDB
 if (!str_detect(cb_ladder, ".csv")){ 
-  control_bc_df <- get_cell_api_info(paste(api_url,"v_control_barcodes", sep = "/"), api_key, 
+  control_bc_df <- get_cell_api_info(paste(api_url,"e_v_control_barcodes", sep = "/"), api_key,
                                      filter = list(where = list(set = cb_ladder), fields = c("sequence", "cb_name", "cb_log10_dose")))
 } else {
   file_path <- file.path(args$out, cb_ladder)

--- a/scripts/create_cellDB_metadata.R
+++ b/scripts/create_cellDB_metadata.R
@@ -113,10 +113,13 @@ if(all(cell_set_meta_long$cell_set %in% assay_pools_meta$davepool_id)) {
     select(cell_set, depmap_id = members)
 }
 
-# Join CB_meta with cell_line_meta
-if (nrow(CB_meta) > 0) {
-  CB_meta <- dplyr::left_join(CB_meta, cell_line_meta, by = "forward_read_barcode")
+# Join CB_meta with cell_line_meta if the depmap_id and lua columns are not present in CB_meta
+if (!all(c("depmap_id", "lua") %in% colnames(CB_meta))) {
+  print("Adding depmap_id and lua columns to CB_meta.")
+  CB_meta <- CB_meta %>%
+    dplyr::left_join(cell_line_meta, by = "forward_read_barcode")
 }
+
 # Writing out cell_line_meta
 cell_line_out_file = paste(args$out, 'cell_line_meta.csv', sep='/')
 print(paste("writing cell_line_meta to: ", cell_line_out_file))

--- a/scripts/filter_counts.R
+++ b/scripts/filter_counts.R
@@ -78,7 +78,7 @@ if(sum(module_outputs$filtered_counts$n) == 0) {
 
 # Also check that cell line counts are not all zeros.
 filtered_counts= module_outputs$filtered_counts
-cl_entries= filtered_counts %>% dplyr::filter(!is.na(depmap_id))
+cl_entries= filtered_counts %>% dplyr::filter(is.na(cb_name))
 if(sum(cl_entries$n) == 0) {
   stop('All cell line counts are zero!')
 }

--- a/scripts/qc_tables.R
+++ b/scripts/qc_tables.R
@@ -81,9 +81,9 @@ pseudocount <- as.numeric(args$pseudocount)
 # CELL LINE BY PLATE (pcr_plate,depmap_id) ---------
 # Filter out control barcodes (where depmap_id is NA) from normalized and filtered counts
 normalized_counts_rm_ctl <- normalized_counts %>%
-    filter(!is.na(depmap_id))
+    filter(is.na(cb_name))
 filtered_counts_rm_ctl <- filtered_counts %>%
-    filter(!is.na(depmap_id))
+    filter(is.na(cb_name))
 plate_cell_table <- generate_cell_plate_table(
     normalized_counts = normalized_counts_rm_ctl, filtered_counts = filtered_counts_rm_ctl,
     cell_line_cols = cell_plate_list, pseudocount = pseudocount)

--- a/scripts/src/QC_images.R
+++ b/scripts/src/QC_images.R
@@ -111,7 +111,7 @@ create_total_counts_barplot= function(filtered_counts, id_cols, facet_col= NA) {
   
   # Sum up reads 
   total_counts= filtered_counts %>%
-    dplyr::mutate(barcode_type= case_when(!is.na(depmap_id) ~ 'cell line',
+    dplyr::mutate(barcode_type= case_when(is.na(cb_name) ~ 'cell line',
                                           !is.na(cb_name) ~ 'ctrl barcode')) %>%
     tidyr::unite(all_of(id_cols), col= 'sample_id', sep= ':', remove= FALSE, na.rm= FALSE) %>%
     dplyr::group_by(pick(all_of(na.omit(c('sample_id', facet_col, 'barcode_type'))))) %>%
@@ -717,7 +717,7 @@ QC_images= function(raw_counts_uncollapsed_path,
   print('9. Generating sample_cor image ...')
   potential_error= base::tryCatch({
     cor_df= filtered_counts %>% 
-      dplyr::filter(!is.na(depmap_id), !pert_type %in% c(NA, 'empty', '', 'CB_only')) %>%
+      dplyr::filter(is.na(cb_name), !pert_type %in% c(NA, 'empty', '', 'CB_only')) %>%
       dplyr::mutate(log2_n= log2(n + 1))
     cp= create_cor_heatmap(input_df= cor_df,
                            row_id_cols= c('depmap_id'),

--- a/scripts/src/compute_l2fc.R
+++ b/scripts/src/compute_l2fc.R
@@ -49,7 +49,7 @@ compute_l2fc= function(normalized_counts,
   print('Collapsing technical replicates on the following columns: ')
   print(unique(c(cell_line_cols, 'pert_type', bio_rep_id_cols, ctrl_cols)))
   collapsed_tech_rep= normalized_counts %>%
-    dplyr::filter(!(pert_type %in% c('empty', '', 'CB_only', NA)), !is.na(depmap_id)) %>%
+    dplyr::filter(!(pert_type %in% c('empty', '', 'CB_only', NA)), is.na(cb_name)) %>%
     dplyr::group_by(pick(all_of(c(cell_line_cols, 'pert_type', bio_rep_id_cols, ctrl_cols)))) %>%
     dplyr::summarise(mean_n= mean(n),
                      mean_normalized_n= mean(2^(!!rlang::sym(count_col_name)))) %>% dplyr::ungroup()

--- a/scripts/src/filter_raw_reads.R
+++ b/scripts/src/filter_raw_reads.R
@@ -95,8 +95,12 @@ filter_raw_reads= function(prism_barcode_counts,
   template= data.table::merge.data.table(sample_meta[!cell_set %in% c(NA, 'NA', '', ' '),],
                                          cell_set_and_pool_meta, by= 'cell_set', allow.cartesian= TRUE)
 
+  write.csv(template, "/cmap/obelix/pod/prismSeq/TEST/MTS_SEQ003_TEST_CL_ENDPOINT/template_1.csv")
+
   # Left join barcode sequence using data.table inplace merge
   template= data.table::merge.data.table(template, cell_line_meta, by= c('depmap_id','lua'), all.x= TRUE, all.y= FALSE)
+
+  write.csv(template, "/cmap/obelix/pod/prismSeq/TEST/MTS_SEQ003_TEST_CL_ENDPOINT/template_2.csv")
 
   # Print 5 random rows of the template
     print('DEBUG: Random entries from template:')
@@ -105,14 +109,19 @@ filter_raw_reads= function(prism_barcode_counts,
   # Check for control barcodes and add them to the template.
   if(any(!unique(sample_meta$cb_ladder) %in% c(NA, 'NA', '', ' '))) {
     # From the sample meta, identify all expected control barcode sequences
-    # Filter for just wells that have cb_ladder(s) present in CB_meta and join the CB_meta
-    # cb_template= data.table::merge.data.table(sample_meta[cb_ladder %in% unique(CB_meta$cb_ladder),],
-    #                                          CB_meta, by= 'cb_ladder', allow.cartesian= TRUE)
-    #template= data.table::rbindlist(list(template, cb_template), fill= TRUE)
+    Filter for just wells that have cb_ladder(s) present in CB_meta and join the CB_meta
+    cb_template= data.table::merge.data.table(sample_meta[cb_ladder %in% unique(CB_meta$cb_ladder),],
+                                              CB_meta, by= 'cb_ladder', allow.cartesian= TRUE)
+    template= data.table::rbindlist(list(template, cb_template), fill= TRUE)
   }
+  write.csv(template, "/cmap/obelix/pod/prismSeq/TEST/MTS_SEQ003_TEST_CL_ENDPOINT/template_3.csv")
+
   
   # Add a column to indicate if a read was expected - this column is used by annotated counts
   template[, expected_read := TRUE]
+
+  write.csv(template, "/cmap/obelix/pod/prismSeq/TEST/MTS_SEQ003_TEST_CL_ENDPOINT/template_4.csv")
+
   
   # Annotating reads ----
   # From prism_barcode_counts, left join metadata to annotate all reads.

--- a/scripts/src/filter_raw_reads.R
+++ b/scripts/src/filter_raw_reads.R
@@ -121,7 +121,7 @@ filter_raw_reads= function(prism_barcode_counts,
   # cell lines not detected in sequencing.
   print("Annotating reads.")
   # Annotate prism_barcode_counts using data.table left joins performed in place!
-  mutate_cols= base::setdiff(colnames(sample_meta), id_colss) # columns to add or update
+  mutate_cols= base::setdiff(colnames(sample_meta), id_cols) # columns to add or update
   values_cols= paste0('i.', mutate_cols)# same as mutate_cols but with 'i.' prefix
   prism_barcode_counts[sample_meta, (mutate_cols) := base::mget(values_cols), on= id_cols]
   # This is equivalent to prism_barcode_counts %<>% dplyr::left_join(sample_meta, by= id_cols)

--- a/scripts/src/filter_raw_reads.R
+++ b/scripts/src/filter_raw_reads.R
@@ -107,7 +107,7 @@ filter_raw_reads= function(prism_barcode_counts,
     # From the sample meta, identify all expected control barcode sequences
     # Filter for just wells that have cb_ladder(s) present in CB_meta and join the CB_meta
     # cb_template= data.table::merge.data.table(sample_meta[cb_ladder %in% unique(CB_meta$cb_ladder),],
-                                              CB_meta, by= 'cb_ladder', allow.cartesian= TRUE)
+    #                                          CB_meta, by= 'cb_ladder', allow.cartesian= TRUE)
     #template= data.table::rbindlist(list(template, cb_template), fill= TRUE)
   }
   

--- a/scripts/src/filter_raw_reads.R
+++ b/scripts/src/filter_raw_reads.R
@@ -98,7 +98,11 @@ filter_raw_reads= function(prism_barcode_counts,
   # Left join barcode sequence using data.table inplace merge
   template= data.table::merge.data.table(template, cell_line_meta, by= c('depmap_id','lua'), all.x= TRUE, all.y= FALSE)
   # template[cell_line_meta, c(barcode_col) := get(barcode_col), on= c('depmap_id', 'lua')]
-  
+
+  # Print 5 random rows of the template
+    print('DEBUG: Random entries from template:')
+    print(template[sample(.N, 5),])
+
   # Check for control barcodes and add them to the template.
   if(any(!unique(sample_meta$cb_ladder) %in% c(NA, 'NA', '', ' '))) {
     # From the sample meta, identify all expected control barcode sequences

--- a/scripts/src/filter_raw_reads.R
+++ b/scripts/src/filter_raw_reads.R
@@ -97,7 +97,6 @@ filter_raw_reads= function(prism_barcode_counts,
 
   # Left join barcode sequence using data.table inplace merge
   template= data.table::merge.data.table(template, cell_line_meta, by= c('depmap_id','lua'), all.x= TRUE, all.y= FALSE)
-  # template[cell_line_meta, c(barcode_col) := get(barcode_col), on= c('depmap_id', 'lua')]
 
   # Print 5 random rows of the template
     print('DEBUG: Random entries from template:')

--- a/scripts/src/filter_raw_reads.R
+++ b/scripts/src/filter_raw_reads.R
@@ -94,8 +94,10 @@ filter_raw_reads= function(prism_barcode_counts,
   # Filter for just wells that have a specified cell set and join cell_set_and_pool_meta
   template= data.table::merge.data.table(sample_meta[!cell_set %in% c(NA, 'NA', '', ' '),],
                                          cell_set_and_pool_meta, by= 'cell_set', allow.cartesian= TRUE)
+
   # Left join barcode sequence using data.table inplace merge
-  template[cell_line_meta, c(barcode_col) := get(barcode_col), on= c('depmap_id', 'lua')]
+  template= data.table::merge.data.table(template, cell_line_meta, by= c('depmap_id','lua'), all.x= TRUE, all.y= FALSE)
+  # template[cell_line_meta, c(barcode_col) := get(barcode_col), on= c('depmap_id', 'lua')]
   
   # Check for control barcodes and add them to the template.
   if(any(!unique(sample_meta$cb_ladder) %in% c(NA, 'NA', '', ' '))) {
@@ -115,7 +117,7 @@ filter_raw_reads= function(prism_barcode_counts,
   # cell lines not detected in sequencing.
   print("Annotating reads.")
   # Annotate prism_barcode_counts using data.table left joins performed in place!
-  mutate_cols= base::setdiff(colnames(sample_meta), id_cols) # columns to add or update
+  mutate_cols= base::setdiff(colnames(sample_meta), id_colss) # columns to add or update
   values_cols= paste0('i.', mutate_cols)# same as mutate_cols but with 'i.' prefix
   prism_barcode_counts[sample_meta, (mutate_cols) := base::mget(values_cols), on= id_cols]
   # This is equivalent to prism_barcode_counts %<>% dplyr::left_join(sample_meta, by= id_cols)

--- a/scripts/src/filter_raw_reads.R
+++ b/scripts/src/filter_raw_reads.R
@@ -109,7 +109,7 @@ filter_raw_reads= function(prism_barcode_counts,
   # Check for control barcodes and add them to the template.
   if(any(!unique(sample_meta$cb_ladder) %in% c(NA, 'NA', '', ' '))) {
     # From the sample meta, identify all expected control barcode sequences
-    Filter for just wells that have cb_ladder(s) present in CB_meta and join the CB_meta
+    # Filter for just wells that have cb_ladder(s) present in CB_meta and join the CB_meta
     cb_template= data.table::merge.data.table(sample_meta[cb_ladder %in% unique(CB_meta$cb_ladder),],
                                               CB_meta, by= 'cb_ladder', allow.cartesian= TRUE)
     template= data.table::rbindlist(list(template, cb_template), fill= TRUE)

--- a/scripts/src/filter_raw_reads.R
+++ b/scripts/src/filter_raw_reads.R
@@ -106,9 +106,9 @@ filter_raw_reads= function(prism_barcode_counts,
   if(any(!unique(sample_meta$cb_ladder) %in% c(NA, 'NA', '', ' '))) {
     # From the sample meta, identify all expected control barcode sequences
     # Filter for just wells that have cb_ladder(s) present in CB_meta and join the CB_meta
-    cb_template= data.table::merge.data.table(sample_meta[cb_ladder %in% unique(CB_meta$cb_ladder),],
+    # cb_template= data.table::merge.data.table(sample_meta[cb_ladder %in% unique(CB_meta$cb_ladder),],
                                               CB_meta, by= 'cb_ladder', allow.cartesian= TRUE)
-    template= data.table::rbindlist(list(template, cb_template), fill= TRUE)
+    #template= data.table::rbindlist(list(template, cb_template), fill= TRUE)
   }
   
   # Add a column to indicate if a read was expected - this column is used by annotated counts

--- a/scripts/src/filter_raw_reads.R
+++ b/scripts/src/filter_raw_reads.R
@@ -95,12 +95,9 @@ filter_raw_reads= function(prism_barcode_counts,
   template= data.table::merge.data.table(sample_meta[!cell_set %in% c(NA, 'NA', '', ' '),],
                                          cell_set_and_pool_meta, by= 'cell_set', allow.cartesian= TRUE)
 
-  write.csv(template, "/cmap/obelix/pod/prismSeq/TEST/MTS_SEQ003_TEST_CL_ENDPOINT/template_1.csv")
-
   # Left join barcode sequence using data.table inplace merge
-  template= data.table::merge.data.table(template, cell_line_meta, by= c('depmap_id','lua'), all.x= TRUE, all.y= FALSE)
-
-  write.csv(template, "/cmap/obelix/pod/prismSeq/TEST/MTS_SEQ003_TEST_CL_ENDPOINT/template_2.csv")
+  # template= data.table::merge.data.table(template, cell_line_meta, by= c('depmap_id','lua'), all.x= TRUE, all.y= FALSE)
+  template[cell_line_meta, c(barcode_col) := get(barcode_col), on= c('depmap_id', 'lua')]
 
   # Print 5 random rows of the template
     print('DEBUG: Random entries from template:')
@@ -114,14 +111,9 @@ filter_raw_reads= function(prism_barcode_counts,
                                               CB_meta, by= 'cb_ladder', allow.cartesian= TRUE)
     template= data.table::rbindlist(list(template, cb_template), fill= TRUE)
   }
-  write.csv(template, "/cmap/obelix/pod/prismSeq/TEST/MTS_SEQ003_TEST_CL_ENDPOINT/template_3.csv")
 
-  
   # Add a column to indicate if a read was expected - this column is used by annotated counts
   template[, expected_read := TRUE]
-
-  write.csv(template, "/cmap/obelix/pod/prismSeq/TEST/MTS_SEQ003_TEST_CL_ENDPOINT/template_4.csv")
-
   
   # Annotating reads ----
   # From prism_barcode_counts, left join metadata to annotate all reads.
@@ -129,7 +121,7 @@ filter_raw_reads= function(prism_barcode_counts,
   # cell lines not detected in sequencing.
   print("Annotating reads.")
   # Annotate prism_barcode_counts using data.table left joins performed in place!
-  mutate_cols= base::setdiff(colnames(sample_meta), id_cols) # columns to add or update
+  mutate_cols= base::setdiff(colnames(sample_meta), id_colss) # columns to add or update
   values_cols= paste0('i.', mutate_cols)# same as mutate_cols but with 'i.' prefix
   prism_barcode_counts[sample_meta, (mutate_cols) := base::mget(values_cols), on= id_cols]
   # This is equivalent to prism_barcode_counts %<>% dplyr::left_join(sample_meta, by= id_cols)


### PR DESCRIPTION
- Updated to use new cell line endpoints (eLab)
- Now join lua and depmap_id to CB_meta in create_cellDB_metadata to avoid duplication of control cell lines downstream
- When filtering for cell lines (removing control barcodes) we now filter for instances where cb_name is null to remove dependence on NAs in depmap_id
