### PR TITLE
Get rid of dependence on poscons for qc_tables

### DIFF
--- a/scripts/qc_tables.R
+++ b/scripts/qc_tables.R
@@ -95,7 +95,7 @@ if (!dir.exists(paste0(args$out, "/qc_tables"))) {
 }
 
 # Check if any samples are positive controls, if not set poscon to FALSE, if so TRUE
-poscon <- any(sample_meta$pert_type == args$poscon_type)
+contains_poscon <- any(sample_meta$pert_type == args$poscon_type)
 
 # DEFINE COLUMNS
 cell_line_cols <- args$cell_line_cols
@@ -166,7 +166,7 @@ filtered_counts_rm_ctl <- filtered_counts %>%
 
 plate_cell_table <- generate_cell_plate_table(
   normalized_counts = filtered_normalized_counts_rm_ctl, filtered_counts = filtered_counts_rm_ctl,
-  cell_line_cols = cell_plate_list, pseudocount = pseudocount, poscon = poscon
+  cell_line_cols = cell_plate_list, pseudocount = pseudocount, contains_poscon = contains_poscon
 )
 
 plate_cell_qc_flags_table <- plate_cell_qc_flags(
@@ -175,7 +175,7 @@ plate_cell_qc_flags_table <- plate_cell_qc_flags(
   error_rate_threshold = thresholds$error_rate_threshold,
   pc_viability_threshold = thresholds$pc_viability_threshold,
   nc_raw_count_threshold = thresholds$nc_raw_count_threshold,
-  contains_poscon = poscon) %>%
+  contains_poscon = contains_poscon) %>%
   dplyr::filter(!is.na(qc_flag))
 
 
@@ -190,7 +190,7 @@ plate_cell_filtered_normalized_counts <-
 
 pcr_plate_qc_flags_table <- generate_pcr_plate_qc_flags_table(plate_cell_table = plate_cell_table,
                                                               fraction_expected_controls = thresholds$fraction_expected_controls,
-                                                              contains_poscon = poscon)
+                                                              contains_poscon = contains_poscon)
 
 final_filtered_normalized_counts <-
   dplyr::anti_join(
@@ -220,7 +220,7 @@ check_file_exists(plate_cell_qc_table_outpath)
 # Write plate_cell_qc_table for portal use
 plate_cell_qc_table_outpath_external <- paste0(args$out, "/qc_tables/plate_cell_qc_table.csv")
 print(paste0("Writing out external plate_cell_qc_table to ", plate_cell_qc_table_outpath_external))
-if (poscon) {
+if (contains_poscon) {
   columns_to_write <- c(
     "pool_id", "depmap_id", "lua", "pcr_plate",
     "pert_plate", "project_code",

--- a/scripts/src/qc_table_functions.R
+++ b/scripts/src/qc_table_functions.R
@@ -304,7 +304,7 @@ compute_ctl_medians_and_mad <- function(df, group_cols = c("depmap_id", "pcr_pla
       median_log_normalized = median(log2_normalized_n),
       n_replicates = n(),
       mad_log_normalized = mad(log2_normalized_n),
-      median_raw = median(log2(n + pseudocount)),
+      median_raw = median(n),
       mad_raw = mad(log2(n + pseudocount))
     ) %>%
     dplyr::ungroup() %>%

--- a/scripts/src/qc_table_functions.R
+++ b/scripts/src/qc_table_functions.R
@@ -401,7 +401,7 @@ compute_cl_fractions <- function(df, metric = "n", grouping_cols = c("pcr_plate"
 #' - Fractions of reads contributed by each cell line.
 #'
 #' @import dplyr
-generate_cell_plate_table <- function(normalized_counts, filtered_counts, cell_line_cols, pseudocount = 20, poscon = TRUE) {
+generate_cell_plate_table <- function(normalized_counts, filtered_counts, cell_line_cols, pseudocount = 20, contains_poscon = TRUE) {
   cell_line_list <- strsplit(cell_line_cols, ",")[[1]]
   cell_line_plate_grouping <- c(cell_line_list, "pcr_plate", "pert_plate", "project_code") # Define columns to group by
   print(paste0("Computing cell + plate QC metrics grouping by ", paste0(cell_line_plate_grouping, collapse = ","), "....."))
@@ -422,7 +422,7 @@ generate_cell_plate_table <- function(normalized_counts, filtered_counts, cell_l
     group_cols = cell_line_plate_grouping,
     negcon = args$negcon_type,
     poscon = args$poscon_type,
-    contains_poscon = poscon
+    contains_poscon = contains_poscon
   )
 
   # Compute poscon LFC
@@ -431,7 +431,7 @@ generate_cell_plate_table <- function(normalized_counts, filtered_counts, cell_l
     negcon = args$negcon_type,
     poscon = args$poscon_type,
     grouping_cols = cell_line_plate_grouping,
-    contains_poscon = poscon
+    contains_poscon = contains_poscon
   )
 
   # Compute cell line fractions per plate


### PR DESCRIPTION
- Checks sample_meta for poscons
- If none are found, does not compute any metrics that relies on it
- Other metrics and table contents are unchanged