### PR TITLE
remove files from modules when we re-run them.

### DIFF
--- a/scripts/collapse_replicates/collapse_replicates.R
+++ b/scripts/collapse_replicates/collapse_replicates.R
@@ -26,6 +26,9 @@ parser$add_argument("-o", "--out", default= getwd(), help= "Output path. Default
 # get command line options, if help option encountered print help and exit
 args <- parser$parse_args()
 
+# If the output file already exists, remove it ----
+delete_existing_files(args$out, "collapsed_l2fc")
+
 # Collapse biological replicates ----
 lfc_values= data.table::fread(args$lfc, header=T, sep=',', data.table=F)
 sig_cols= unlist(strsplit(args$sig_cols, ","))

--- a/scripts/collate_counts/collate_counts.R
+++ b/scripts/collate_counts/collate_counts.R
@@ -37,6 +37,9 @@ if (args$out == "") {
   args$out = args$wkdir
 }
 
+# If the output files already exist, remove them ----
+delete_existing_files(args$out, "barcode_counts")
+
 # Read in metadata files as data.table objects ----
 cell_line_meta= data.table::fread(args$cell_line_meta, header= TRUE, sep= ',')
 CB_meta= data.table::fread(args$CB_meta, header= TRUE, sep= ',')

--- a/scripts/compute_l2fc/compute_l2fc.R
+++ b/scripts/compute_l2fc/compute_l2fc.R
@@ -42,6 +42,9 @@ cell_line_cols= unlist(strsplit(args$cell_line_cols, ","))
 count_col_name = args$count_col_name
 qc_path = args$qc_path
 
+# If l2fc files already exist, remove them ----
+delete_existing_files(args$out, "^l2fc")
+
 print("Collapsing tech reps and computing log-fold change ...")
 l2fc= compute_l2fc(normalized_counts= normalized_counts, 
                    control_type= control_type, 

--- a/scripts/filter_counts/filter_counts.R
+++ b/scripts/filter_counts/filter_counts.R
@@ -46,6 +46,10 @@ if (args$out == ""){
 }
 #print_args(args)
 
+# If output files already exist, remove them ----
+delete_existing_files(args$out, "filtered_counts")
+delete_existing_files(args$out, "annotated_counts")
+
 # Read in all input files ----
 prism_barcode_counts= data.table::fread(args$prism_barcode_counts, header= TRUE, sep= ',')
 sample_meta= data.table::fread(args$sample_meta, header= TRUE, sep= ',')

--- a/scripts/normalize/normalize.R
+++ b/scripts/normalize/normalize.R
@@ -29,6 +29,9 @@ CB_meta= data.table::fread(args$CB_meta, header= TRUE, sep= ',')
 input_pseudocount= as.numeric(args$pseudocount)
 input_id_cols= unlist(strsplit(args$id_cols, ","))
 
+# If normalized counts files already exists, remove them ----
+delete_existing_files(args$out, "normalized_counts")
+
 # Run normalize ----
 print("Creating normalized count file ...")
 normalized_counts = normalize(X= filtered_counts, id_cols= input_id_cols,

--- a/scripts/utils/kitchen_utensils.R
+++ b/scripts/utils/kitchen_utensils.R
@@ -147,3 +147,22 @@ append_critical_output <- function(statement, out) {
   # Append to file
   cat(statement, file = paste0(out, "/logs/critical_output.txt"), append = TRUE, sep = "\n")
 }
+
+#' Delete existing files when re-running a module
+#'
+#' This function deletes existing files in a given output directory that match a given pattern.
+#' This is useful when re-running a module to ensure that old files do not interfere with
+#' the new output.
+#' @param out_dir The output directory to check for existing files.
+#' @param pattern A pattern to match files against. This can be a regular expression.
+delete_existing_files <- function(out_dir, pattern) {
+  files_to_delete <- list.files(path = out_dir, pattern = pattern, full.names = TRUE)
+  if (length(files_to_delete) > 0) {
+    file.remove(files_to_delete)
+    message(paste("Deleted", length(files_to_delete), "existing files in", out_dir))
+    message("Deleted files:")
+    print(files_to_delete)
+  } else {
+    message(paste("No existing files to delete in", out_dir))
+  }
+}


### PR DESCRIPTION
Remove files from l2fc, collapsed_l2fc, normalized_counts, filtered_counts, annotated counts when re-running modules