### PR TITLE
- hotfix to prevent contamination flags from wells not in sample_meta

### DIFF
--- a/scripts/qc_tables/qc_tables.R
+++ b/scripts/qc_tables/qc_tables.R
@@ -110,6 +110,13 @@ prism_barcode_counts <- data.table::fread(args$prism_barcode_counts, header = TR
 print(paste0("Reading in ", args$cell_line_meta, "....."))
 cell_line_meta <- data.table::fread(args$cell_line_meta, header = TRUE, sep = ",")
 
+# Join unknown_counts and prism_barcode_counts with sample_meta to ensure only appropriate wells are kept
+unknown_counts <- unknown_counts %>%
+  right_join(sample_meta %>% select(pcr_plate, pcr_well), by = c("pcr_plate", "pcr_well"))
+
+prism_barcode_counts <- prism_barcode_counts %>%
+    right_join(sample_meta %>% select(pcr_plate, pcr_well), by =c("pcr_plate", "pcr_well"))
+
 # Check if the output directory exists, if not create it
 if (!dir.exists(paste0(args$out, "/qc_tables"))) {
   dir.create(paste0(args$out, "/qc_tables"))


### PR DESCRIPTION
- qc_tables uses unknown_barcode_counts and prism_barcode_counts to compute contamination
- in some circumstances these tables may contain all wells, including those not in sample_metadata, which is not desired behavior
- prior to computing id_cols table we now ensure that only matching pcr_plate + pcr_well rows exist in these tables